### PR TITLE
Feature/phase 2 scriptable conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,15 @@ apps/**/src-tauri/gen/
 .DS_Store
 Thumbs.db
 
+# Claude Code temporary directories
+tmpclaude-*
+
+# Claude local settings
+.claude/settings.local.json
+
+# Plastic SCM
+.plastic/
+
+# Unity auto-generated solution files
+*.slnx
+

--- a/Assets/Data/Conditions.meta
+++ b/Assets/Data/Conditions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7c246a609ce05a40a5dee086da4aa96
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.ai_managers_69.asset
+++ b/Assets/Data/Conditions/condition.ai_managers_69.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.ai_managers_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: a2bfbaf4830f7a04bb52f12ff32fb517, type: 2}
+  _countType: 1
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.ai_managers_69.asset.meta
+++ b/Assets/Data/Conditions/condition.ai_managers_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d39788aa6ef47314f87f5443791d7109
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.assembly_lines_69.asset
+++ b/Assets/Data/Conditions/condition.assembly_lines_69.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.assembly_lines_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 3591d7035410d2041962d5dcfc341f99, type: 2}
+  _countType: 1
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.assembly_lines_69.asset.meta
+++ b/Assets/Data/Conditions/condition.assembly_lines_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf69a4e2a0abff949a50bafd6dbc055e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.assembly_lines_total_gte_10.asset
+++ b/Assets/Data/Conditions/condition.assembly_lines_total_gte_10.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.assembly_lines_total_gte_10
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 3591d7035410d2041962d5dcfc341f99, type: 2}
+  _countType: 0
+  _operator: 3
+  _threshold: 10

--- a/Assets/Data/Conditions/condition.assembly_lines_total_gte_10.asset.meta
+++ b/Assets/Data/Conditions/condition.assembly_lines_total_gte_10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f8dbddf311bd3842ba48c61a09a4a31
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.data_centers_69.asset
+++ b/Assets/Data/Conditions/condition.data_centers_69.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.data_centers_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: a486655d6dbe30943b160eae6b58a1f9, type: 2}
+  _countType: 1
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.data_centers_69.asset.meta
+++ b/Assets/Data/Conditions/condition.data_centers_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbf0b6c370d0f2749b854942d4910c5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.effective_owned_gte_69.asset
+++ b/Assets/Data/Conditions/condition.effective_owned_gte_69.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8a6561ade151b142999076617ccfdc8, type: 3}
+  m_Name: condition.effective_owned_gte_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityStateCondition
+  _description: 
+  _property: 2
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.effective_owned_gte_69.asset.meta
+++ b/Assets/Data/Conditions/condition.effective_owned_gte_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6751f42f2a0f2146879412eabdc9b2f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.manual_owned_gte_69.asset
+++ b/Assets/Data/Conditions/condition.manual_owned_gte_69.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8a6561ade151b142999076617ccfdc8, type: 3}
+  m_Name: condition.manual_owned_gte_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityStateCondition
+  _description: 
+  _property: 0
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.manual_owned_gte_69.asset.meta
+++ b/Assets/Data/Conditions/condition.manual_owned_gte_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 776e8de7328ad3c48a370624f37561f7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.panel_lifetime.asset
+++ b/Assets/Data/Conditions/condition.panel_lifetime.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45ef4258e9bfa7c4bb25840dd3ee264f, type: 3}
+  m_Name: condition.panel_lifetime
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.PanelLifetimeCondition
+  _description: 
+  _operator: 2
+  _threshold: 0

--- a/Assets/Data/Conditions/condition.panel_lifetime.asset.meta
+++ b/Assets/Data/Conditions/condition.panel_lifetime.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4d20511a60fcfc46968ef42ec7f0324
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.planets_69.asset
+++ b/Assets/Data/Conditions/condition.planets_69.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.planets_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 8ac9f40771445e047b67a4078b73b2f6, type: 2}
+  _countType: 1
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.planets_69.asset.meta
+++ b/Assets/Data/Conditions/condition.planets_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2403ce23c9168cc4393d15686358d810
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.planets_total_gte_2.asset
+++ b/Assets/Data/Conditions/condition.planets_total_gte_2.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.planets_total_gte_2
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 8ac9f40771445e047b67a4078b73b2f6, type: 2}
+  _countType: 0
+  _operator: 3
+  _threshold: 2

--- a/Assets/Data/Conditions/condition.planets_total_gte_2.asset.meta
+++ b/Assets/Data/Conditions/condition.planets_total_gte_2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 296027b04a151dd49908332011846113
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.researchers_gt_1.asset
+++ b/Assets/Data/Conditions/condition.researchers_gt_1.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37dc2bc0f970b0f4899aa19760d1c1f8, type: 3}
+  m_Name: condition.researchers_gt_1
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.WorkerCountCondition
+  _description: 
+  _workerType: 2
+  _operator: 2
+  _threshold: 1

--- a/Assets/Data/Conditions/condition.researchers_gt_1.asset.meta
+++ b/Assets/Data/Conditions/condition.researchers_gt_1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3314a33507e32514e8be7179dcf98d5d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.servers_69.asset
+++ b/Assets/Data/Conditions/condition.servers_69.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.servers_69
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 3c96fbf9fe6d7f34c8a544d94b87e2c6, type: 2}
+  _countType: 1
+  _operator: 3
+  _threshold: 69

--- a/Assets/Data/Conditions/condition.servers_69.asset.meta
+++ b/Assets/Data/Conditions/condition.servers_69.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81443427a9abead47af4d02969791819
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.servers_total_gt_1.asset
+++ b/Assets/Data/Conditions/condition.servers_total_gt_1.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec1e57c5047884d459cb9658eb0efc42, type: 3}
+  m_Name: condition.servers_total_gt_1
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.FacilityCountCondition
+  _description: 
+  _facilityId: {fileID: 11400000, guid: 3c96fbf9fe6d7f34c8a544d94b87e2c6, type: 2}
+  _countType: 0
+  _operator: 2
+  _threshold: 1

--- a/Assets/Data/Conditions/condition.servers_total_gt_1.asset.meta
+++ b/Assets/Data/Conditions/condition.servers_total_gt_1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdce65e10f5bca14d9a4171b99dc5336
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Conditions/condition.workers_gt_1.asset
+++ b/Assets/Data/Conditions/condition.workers_gt_1.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37dc2bc0f970b0f4899aa19760d1c1f8, type: 3}
+  m_Name: condition.workers_gt_1
+  m_EditorClassIdentifier: Assembly-CSharp::IdleDysonSwarm.Data.Conditions.WorkerCountCondition
+  _description: 
+  _workerType: 1
+  _operator: 2
+  _threshold: 1

--- a/Assets/Data/Conditions/condition.workers_gt_1.asset.meta
+++ b/Assets/Data/Conditions/condition.workers_gt_1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11c8279a5e141ac4ca11230362c1593e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Effects/effect.rule34.ai_managers.asset
+++ b/Assets/Data/Effects/effect.rule34.ai_managers.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   value: 2
   perLevel: 0
   order: 20
+  _condition: {fileID: 11400000, guid: d39788aa6ef47314f87f5443791d7109, type: 2}
   conditionId: ai_managers_69
   targetFacilityIds:
   - ai_managers

--- a/Assets/Data/Effects/effect.rule34.assembly_lines.asset
+++ b/Assets/Data/Effects/effect.rule34.assembly_lines.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   value: 2
   perLevel: 0
   order: 30
+  _condition: {fileID: 11400000, guid: bf69a4e2a0abff949a50bafd6dbc055e, type: 2}
   conditionId: assembly_lines_69
   targetFacilityIds:
   - assembly_lines

--- a/Assets/Data/Effects/effect.rule34.data_centers.asset
+++ b/Assets/Data/Effects/effect.rule34.data_centers.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   value: 2
   perLevel: 0
   order: 20
+  _condition: {fileID: 11400000, guid: dbf0b6c370d0f2749b854942d4910c5c, type: 2}
   conditionId: data_centers_69
   targetFacilityIds:
   - data_centers

--- a/Assets/Data/Effects/effect.rule34.planets.asset
+++ b/Assets/Data/Effects/effect.rule34.planets.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   value: 2
   perLevel: 0
   order: 20
+  _condition: {fileID: 11400000, guid: 2403ce23c9168cc4393d15686358d810, type: 2}
   conditionId: planets_69
   targetFacilityIds:
   - planets

--- a/Assets/Data/Effects/effect.rule34.servers.asset
+++ b/Assets/Data/Effects/effect.rule34.servers.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   value: 2
   perLevel: 0
   order: 20
+  _condition: {fileID: 11400000, guid: 81443427a9abead47af4d02969791819, type: 2}
   conditionId: servers_69
   targetFacilityIds:
   - servers

--- a/Assets/Editor/ConditionAssignmentTool.cs
+++ b/Assets/Editor/ConditionAssignmentTool.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using GameData;
+using IdleDysonSwarm.Data.Conditions;
+using UnityEditor;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Editor
+{
+    /// <summary>
+    /// Tool to automatically assign generated condition assets to EffectDefinitions
+    /// that currently use matching string conditionIds.
+    /// </summary>
+    public static class ConditionAssignmentTool
+    {
+        private const string CONDITIONS_PATH = "Assets/Data/Conditions";
+
+        [MenuItem("Tools/Idle Dyson Swarm/Migrate Conditions/Assign Conditions to Effects", priority = 52)]
+        public static void AssignConditionsToEffects()
+        {
+            Debug.Log("[ConditionAssignmentTool] Starting automatic condition assignment...");
+
+            // Load all condition assets
+            var conditionsByName = LoadAllConditions();
+            Debug.Log($"[ConditionAssignmentTool] Loaded {conditionsByName.Count} condition assets");
+
+            // Find all EffectDefinition assets
+            string[] effectGuids = AssetDatabase.FindAssets("t:EffectDefinition");
+            int assigned = 0;
+            int skipped = 0;
+            int noMatch = 0;
+
+            foreach (string guid in effectGuids)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                var effect = AssetDatabase.LoadAssetAtPath<EffectDefinition>(assetPath);
+
+                if (effect == null)
+                {
+                    Debug.LogWarning($"[ConditionAssignmentTool] Failed to load effect: {assetPath}");
+                    continue;
+                }
+
+                // Skip if already has a scriptable condition assigned
+                if (effect.UsesScriptableCondition)
+                {
+                    Debug.Log($"[ConditionAssignmentTool] Skipping '{effect.name}' - already has scriptable condition");
+                    skipped++;
+                    continue;
+                }
+
+                // Skip if no legacy conditionId
+                if (string.IsNullOrEmpty(effect.conditionId))
+                {
+                    noMatch++;
+                    continue;
+                }
+
+                // Try to find matching condition asset
+                string conditionAssetName = $"condition.{effect.conditionId}";
+                if (conditionsByName.TryGetValue(conditionAssetName, out EffectCondition condition))
+                {
+                    // Assign the condition using reflection (since _condition is private)
+                    var field = typeof(EffectDefinition).GetField("_condition",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+                    if (field != null)
+                    {
+                        field.SetValue(effect, condition);
+                        EditorUtility.SetDirty(effect);
+                        Debug.Log($"[ConditionAssignmentTool] Assigned '{conditionAssetName}' to effect '{effect.name}' (conditionId: '{effect.conditionId}')");
+                        assigned++;
+                    }
+                    else
+                    {
+                        Debug.LogError($"[ConditionAssignmentTool] Failed to find _condition field on EffectDefinition");
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning($"[ConditionAssignmentTool] No matching condition asset for '{effect.name}' (conditionId: '{effect.conditionId}')");
+                    noMatch++;
+                }
+            }
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"[ConditionAssignmentTool] ==========================================");
+            Debug.Log($"[ConditionAssignmentTool] ASSIGNMENT COMPLETE!");
+            Debug.Log($"[ConditionAssignmentTool] Assigned: {assigned}");
+            Debug.Log($"[ConditionAssignmentTool] Skipped (already has condition): {skipped}");
+            Debug.Log($"[ConditionAssignmentTool] No matching condition: {noMatch}");
+            Debug.Log($"[ConditionAssignmentTool] Total effects processed: {effectGuids.Length}");
+            Debug.Log($"[ConditionAssignmentTool] ==========================================");
+        }
+
+        private static Dictionary<string, EffectCondition> LoadAllConditions()
+        {
+            var result = new Dictionary<string, EffectCondition>();
+
+            if (!AssetDatabase.IsValidFolder(CONDITIONS_PATH))
+            {
+                Debug.LogWarning($"[ConditionAssignmentTool] Conditions folder not found: {CONDITIONS_PATH}");
+                return result;
+            }
+
+            string[] guids = AssetDatabase.FindAssets("t:EffectCondition", new[] { CONDITIONS_PATH });
+
+            foreach (string guid in guids)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                var condition = AssetDatabase.LoadAssetAtPath<EffectCondition>(assetPath);
+
+                if (condition != null)
+                {
+                    result[condition.name] = condition;
+                }
+            }
+
+            return result;
+        }
+
+        [MenuItem("Tools/Idle Dyson Swarm/Migrate Conditions/Report Effect Conditions", priority = 53)]
+        public static void ReportEffectConditions()
+        {
+            Debug.Log("[ConditionAssignmentTool] Generating condition usage report...");
+
+            string[] effectGuids = AssetDatabase.FindAssets("t:EffectDefinition");
+            int withScriptable = 0;
+            int withLegacyOnly = 0;
+            int withBoth = 0;
+            int withNone = 0;
+
+            foreach (string guid in effectGuids)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                var effect = AssetDatabase.LoadAssetAtPath<EffectDefinition>(assetPath);
+
+                if (effect == null) continue;
+
+                bool hasScriptable = effect.UsesScriptableCondition;
+                bool hasLegacy = !string.IsNullOrEmpty(effect.conditionId);
+
+                if (hasScriptable && hasLegacy)
+                {
+                    withBoth++;
+                }
+                else if (hasScriptable)
+                {
+                    withScriptable++;
+                }
+                else if (hasLegacy)
+                {
+                    withLegacyOnly++;
+                }
+                else
+                {
+                    withNone++;
+                }
+            }
+
+            Debug.Log($"[ConditionAssignmentTool] ==========================================");
+            Debug.Log($"[ConditionAssignmentTool] CONDITION USAGE REPORT");
+            Debug.Log($"[ConditionAssignmentTool] Total effects: {effectGuids.Length}");
+            Debug.Log($"[ConditionAssignmentTool] With scriptable condition only: {withScriptable}");
+            Debug.Log($"[ConditionAssignmentTool] With legacy conditionId only: {withLegacyOnly}");
+            Debug.Log($"[ConditionAssignmentTool] With both (scriptable takes precedence): {withBoth}");
+            Debug.Log($"[ConditionAssignmentTool] With no condition: {withNone}");
+            Debug.Log($"[ConditionAssignmentTool] ==========================================");
+            Debug.Log($"[ConditionAssignmentTool] Migration progress: {withScriptable + withBoth}/{withScriptable + withBoth + withLegacyOnly} effects using scriptable conditions");
+        }
+    }
+}

--- a/Assets/Editor/ConditionAssignmentTool.cs.meta
+++ b/Assets/Editor/ConditionAssignmentTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d519c99e7c0583a4a883a9596c5e9f46

--- a/Assets/Editor/ConditionMigrationTool.cs
+++ b/Assets/Editor/ConditionMigrationTool.cs
@@ -1,0 +1,308 @@
+using System.Collections.Generic;
+using System.IO;
+using GameData;
+using IdleDysonSwarm.Data;
+using IdleDysonSwarm.Data.Conditions;
+using UnityEditor;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Editor
+{
+    /// <summary>
+    /// Editor tool to migrate string-based conditionIds to scriptable condition assets.
+    /// Scans all EffectDefinition assets and generates corresponding condition assets.
+    /// </summary>
+    public static class ConditionMigrationTool
+    {
+        private const string CONDITIONS_OUTPUT_PATH = "Assets/Data/Conditions";
+        private const string FACILITY_IDS_PATH = "Assets/Data/IDs/Facilities";
+
+        [MenuItem("Tools/Idle Dyson Swarm/Migrate Conditions/Scan ConditionIds", priority = 50)]
+        public static void ScanConditionIds()
+        {
+            Debug.Log("[ConditionMigrationTool] Scanning for conditionIds in EffectDefinitions...");
+
+            var conditionIds = new HashSet<string>();
+            string[] guids = AssetDatabase.FindAssets("t:EffectDefinition");
+
+            foreach (string guid in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                var effect = AssetDatabase.LoadAssetAtPath<EffectDefinition>(path);
+
+                if (effect != null && !string.IsNullOrEmpty(effect.conditionId))
+                {
+                    conditionIds.Add(effect.conditionId);
+                }
+            }
+
+            Debug.Log($"[ConditionMigrationTool] Found {conditionIds.Count} unique conditionIds:");
+            foreach (string conditionId in conditionIds)
+            {
+                Debug.Log($"  - {conditionId}");
+            }
+        }
+
+        [MenuItem("Tools/Idle Dyson Swarm/Migrate Conditions/Generate Condition Assets", priority = 51)]
+        public static void GenerateConditionAssets()
+        {
+            Debug.Log("[ConditionMigrationTool] Generating condition assets...");
+
+            EnsureOutputFolderExists();
+
+            int created = 0;
+            int skipped = 0;
+
+            // Define all known conditions and their configurations
+            var conditionConfigs = new List<ConditionConfig>
+            {
+                // Facility count conditions (manual >= 69)
+                new FacilityCountConfig("assembly_lines_69", "assembly_lines", FacilityCountType.ManualOnly, ComparisonOperator.GreaterOrEqual, 69),
+                new FacilityCountConfig("ai_managers_69", "ai_managers", FacilityCountType.ManualOnly, ComparisonOperator.GreaterOrEqual, 69),
+                new FacilityCountConfig("servers_69", "servers", FacilityCountType.ManualOnly, ComparisonOperator.GreaterOrEqual, 69),
+                new FacilityCountConfig("data_centers_69", "data_centers", FacilityCountType.ManualOnly, ComparisonOperator.GreaterOrEqual, 69),
+                new FacilityCountConfig("planets_69", "planets", FacilityCountType.ManualOnly, ComparisonOperator.GreaterOrEqual, 69),
+
+                // Facility count conditions (total thresholds)
+                new FacilityCountConfig("servers_total_gt_1", "servers", FacilityCountType.Total, ComparisonOperator.GreaterThan, 1),
+                new FacilityCountConfig("assembly_lines_total_gte_10", "assembly_lines", FacilityCountType.Total, ComparisonOperator.GreaterOrEqual, 10),
+                new FacilityCountConfig("planets_total_gte_2", "planets", FacilityCountType.Total, ComparisonOperator.GreaterOrEqual, 2),
+
+                // Worker conditions
+                new WorkerCountConfig("workers_gt_1", WorkerType.Workers, ComparisonOperator.GreaterThan, 1),
+                new WorkerCountConfig("researchers_gt_1", WorkerType.Researchers, ComparisonOperator.GreaterThan, 1),
+
+                // Panel lifetime condition
+                new PanelLifetimeConfig("panel_lifetime", ComparisonOperator.GreaterThan, 0),
+
+                // Facility state conditions (context-dependent)
+                new FacilityStateConfig("manual_owned_gte_69", FacilityStateProperty.ManualOwned, ComparisonOperator.GreaterOrEqual, 69),
+                new FacilityStateConfig("effective_owned_gte_69", FacilityStateProperty.EffectiveCount, ComparisonOperator.GreaterOrEqual, 69),
+            };
+
+            foreach (var config in conditionConfigs)
+            {
+                if (config.CreateAsset(CONDITIONS_OUTPUT_PATH))
+                    created++;
+                else
+                    skipped++;
+            }
+
+            // Note: bots_required_met is complex and requires a custom condition class
+
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"[ConditionMigrationTool] ==========================================");
+            Debug.Log($"[ConditionMigrationTool] GENERATION COMPLETE!");
+            Debug.Log($"[ConditionMigrationTool] Created: {created}, Skipped: {skipped}");
+            Debug.Log($"[ConditionMigrationTool] ==========================================");
+            Debug.Log($"[ConditionMigrationTool] Note: 'bots_required_met' requires a custom condition class.");
+        }
+
+        private static void EnsureOutputFolderExists()
+        {
+            if (!AssetDatabase.IsValidFolder(CONDITIONS_OUTPUT_PATH))
+            {
+                string parent = Path.GetDirectoryName(CONDITIONS_OUTPUT_PATH).Replace("\\", "/");
+                string folderName = Path.GetFileName(CONDITIONS_OUTPUT_PATH);
+
+                if (!AssetDatabase.IsValidFolder(parent))
+                {
+                    AssetDatabase.CreateFolder("Assets/Data", "Conditions");
+                }
+                else
+                {
+                    AssetDatabase.CreateFolder(parent, folderName);
+                }
+            }
+        }
+
+        #region Condition Configuration Classes
+
+        private abstract class ConditionConfig
+        {
+            public string ConditionId { get; }
+
+            protected ConditionConfig(string conditionId)
+            {
+                ConditionId = conditionId;
+            }
+
+            public abstract bool CreateAsset(string outputPath);
+
+            protected bool AssetExists(string path)
+            {
+                return AssetDatabase.LoadAssetAtPath<ScriptableObject>(path) != null;
+            }
+        }
+
+        private class FacilityCountConfig : ConditionConfig
+        {
+            private readonly string _facilityId;
+            private readonly FacilityCountType _countType;
+            private readonly ComparisonOperator _operator;
+            private readonly int _threshold;
+
+            public FacilityCountConfig(string conditionId, string facilityId, FacilityCountType countType,
+                ComparisonOperator op, int threshold) : base(conditionId)
+            {
+                _facilityId = facilityId;
+                _countType = countType;
+                _operator = op;
+                _threshold = threshold;
+            }
+
+            public override bool CreateAsset(string outputPath)
+            {
+                string assetPath = $"{outputPath}/condition.{ConditionId}.asset";
+
+                if (AssetExists(assetPath))
+                {
+                    Debug.Log($"[ConditionMigrationTool] Skipping (exists): {assetPath}");
+                    return false;
+                }
+
+                // Load the facility ID asset
+                string facilityIdPath = $"{FACILITY_IDS_PATH}/{_facilityId}.asset";
+                var facilityId = AssetDatabase.LoadAssetAtPath<FacilityId>(facilityIdPath);
+
+                if (facilityId == null)
+                {
+                    Debug.LogWarning($"[ConditionMigrationTool] FacilityId not found: {facilityIdPath}");
+                    return false;
+                }
+
+                var condition = ScriptableObject.CreateInstance<FacilityCountCondition>();
+                SetFieldValue(condition, "_facilityId", facilityId);
+                SetFieldValue(condition, "_countType", _countType);
+                SetFieldValue(condition, "_operator", _operator);
+                SetFieldValue(condition, "_threshold", _threshold);
+
+                AssetDatabase.CreateAsset(condition, assetPath);
+                Debug.Log($"[ConditionMigrationTool] Created: {assetPath}");
+                return true;
+            }
+        }
+
+        private class WorkerCountConfig : ConditionConfig
+        {
+            private readonly WorkerType _workerType;
+            private readonly ComparisonOperator _operator;
+            private readonly double _threshold;
+
+            public WorkerCountConfig(string conditionId, WorkerType workerType, ComparisonOperator op, double threshold)
+                : base(conditionId)
+            {
+                _workerType = workerType;
+                _operator = op;
+                _threshold = threshold;
+            }
+
+            public override bool CreateAsset(string outputPath)
+            {
+                string assetPath = $"{outputPath}/condition.{ConditionId}.asset";
+
+                if (AssetExists(assetPath))
+                {
+                    Debug.Log($"[ConditionMigrationTool] Skipping (exists): {assetPath}");
+                    return false;
+                }
+
+                var condition = ScriptableObject.CreateInstance<WorkerCountCondition>();
+                SetFieldValue(condition, "_workerType", _workerType);
+                SetFieldValue(condition, "_operator", _operator);
+                SetFieldValue(condition, "_threshold", _threshold);
+
+                AssetDatabase.CreateAsset(condition, assetPath);
+                Debug.Log($"[ConditionMigrationTool] Created: {assetPath}");
+                return true;
+            }
+        }
+
+        private class PanelLifetimeConfig : ConditionConfig
+        {
+            private readonly ComparisonOperator _operator;
+            private readonly double _threshold;
+
+            public PanelLifetimeConfig(string conditionId, ComparisonOperator op, double threshold)
+                : base(conditionId)
+            {
+                _operator = op;
+                _threshold = threshold;
+            }
+
+            public override bool CreateAsset(string outputPath)
+            {
+                string assetPath = $"{outputPath}/condition.{ConditionId}.asset";
+
+                if (AssetExists(assetPath))
+                {
+                    Debug.Log($"[ConditionMigrationTool] Skipping (exists): {assetPath}");
+                    return false;
+                }
+
+                var condition = ScriptableObject.CreateInstance<PanelLifetimeCondition>();
+                SetFieldValue(condition, "_operator", _operator);
+                SetFieldValue(condition, "_threshold", _threshold);
+
+                AssetDatabase.CreateAsset(condition, assetPath);
+                Debug.Log($"[ConditionMigrationTool] Created: {assetPath}");
+                return true;
+            }
+        }
+
+        private class FacilityStateConfig : ConditionConfig
+        {
+            private readonly FacilityStateProperty _property;
+            private readonly ComparisonOperator _operator;
+            private readonly int _threshold;
+
+            public FacilityStateConfig(string conditionId, FacilityStateProperty property,
+                ComparisonOperator op, int threshold) : base(conditionId)
+            {
+                _property = property;
+                _operator = op;
+                _threshold = threshold;
+            }
+
+            public override bool CreateAsset(string outputPath)
+            {
+                string assetPath = $"{outputPath}/condition.{ConditionId}.asset";
+
+                if (AssetExists(assetPath))
+                {
+                    Debug.Log($"[ConditionMigrationTool] Skipping (exists): {assetPath}");
+                    return false;
+                }
+
+                var condition = ScriptableObject.CreateInstance<FacilityStateCondition>();
+                SetFieldValue(condition, "_property", _property);
+                SetFieldValue(condition, "_operator", _operator);
+                SetFieldValue(condition, "_threshold", _threshold);
+
+                AssetDatabase.CreateAsset(condition, assetPath);
+                Debug.Log($"[ConditionMigrationTool] Created: {assetPath}");
+                return true;
+            }
+        }
+
+        #endregion
+
+        private static void SetFieldValue<T>(T obj, string fieldName, object value)
+        {
+            var field = typeof(T).GetField(fieldName,
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+
+            if (field != null)
+            {
+                field.SetValue(obj, value);
+            }
+            else
+            {
+                Debug.LogWarning($"[ConditionMigrationTool] Field '{fieldName}' not found on {typeof(T).Name}");
+            }
+        }
+    }
+}

--- a/Assets/Editor/ConditionMigrationTool.cs.meta
+++ b/Assets/Editor/ConditionMigrationTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: add270b58f6cd604dab64ea8f145fdac

--- a/Assets/Editor/EffectConditionDrawer.cs
+++ b/Assets/Editor/EffectConditionDrawer.cs
@@ -1,0 +1,53 @@
+using IdleDysonSwarm.Data.Conditions;
+using UnityEditor;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Editor
+{
+    /// <summary>
+    /// Custom property drawer for EffectCondition fields.
+    /// Shows the condition's description inline in the inspector.
+    /// </summary>
+    [CustomPropertyDrawer(typeof(EffectCondition), true)]
+    public class EffectConditionDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            // Calculate rects
+            float lineHeight = EditorGUIUtility.singleLineHeight;
+            float spacing = EditorGUIUtility.standardVerticalSpacing;
+
+            Rect objectFieldRect = new Rect(position.x, position.y, position.width, lineHeight);
+            Rect descriptionRect = new Rect(position.x + 15, position.y + lineHeight + spacing,
+                position.width - 15, lineHeight);
+
+            // Draw the object field
+            EditorGUI.PropertyField(objectFieldRect, property, label);
+
+            // Draw the description if a condition is assigned
+            var condition = property.objectReferenceValue as EffectCondition;
+            if (condition != null)
+            {
+                string description = condition.GetDescription();
+                EditorGUI.LabelField(descriptionRect, description, EditorStyles.miniLabel);
+            }
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            float height = EditorGUIUtility.singleLineHeight;
+
+            // Add space for description if condition is assigned
+            if (property.objectReferenceValue != null)
+            {
+                height += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            }
+
+            return height;
+        }
+    }
+}

--- a/Assets/Editor/EffectConditionDrawer.cs.meta
+++ b/Assets/Editor/EffectConditionDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9938f7a6c33b1be4f854a5b9be02672b

--- a/Assets/Scripts/Data/Conditions.meta
+++ b/Assets/Scripts/Data/Conditions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ceb3b51a03e69c4fb23404c36d9d26b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Conditions/AndCondition.cs
+++ b/Assets/Scripts/Data/Conditions/AndCondition.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Text;
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Composite condition that evaluates to true only if ALL child conditions are true.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Composite/AND")]
+    public sealed class AndCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("All of these conditions must be true for this condition to be true.")]
+        private EffectCondition[] _conditions;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return true; // No conditions = always true
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null)
+                    continue;
+
+                if (!condition.Evaluate(context))
+                    return false;
+            }
+
+            return true;
+        }
+
+        protected override string GenerateDescription()
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return "Always True (no conditions)";
+
+            var validConditions = _conditions.Where(c => c != null).ToArray();
+            if (validConditions.Length == 0)
+                return "Always True (no conditions)";
+
+            if (validConditions.Length == 1)
+                return validConditions[0].GetDescription();
+
+            var sb = new StringBuilder();
+            sb.Append("ALL OF: [");
+            for (int i = 0; i < validConditions.Length; i++)
+            {
+                if (i > 0) sb.Append(" AND ");
+                sb.Append(validConditions[i].GetDescription());
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return "All conditions met (empty)";
+
+            int metCount = 0;
+            int totalCount = 0;
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null) continue;
+                totalCount++;
+                if (condition.Evaluate(context))
+                    metCount++;
+            }
+
+            bool allMet = metCount == totalCount;
+            return $"{metCount}/{totalCount} conditions met ({(allMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/AndCondition.cs
+++ b/Assets/Scripts/Data/Conditions/AndCondition.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Systems.Facilities;
 using Systems.Stats;
 using UnityEngine;
 
@@ -26,6 +27,23 @@ namespace IdleDysonSwarm.Data.Conditions
                     continue;
 
                 if (!condition.Evaluate(context))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override bool EvaluateWithState(EffectContext context, FacilityState state)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return true; // No conditions = always true
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null)
+                    continue;
+
+                if (!condition.EvaluateWithState(context, state))
                     return false;
             }
 

--- a/Assets/Scripts/Data/Conditions/AndCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/AndCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c4f5146a0e8da3408f003c9fd3f8986

--- a/Assets/Scripts/Data/Conditions/ComparisonOperator.cs
+++ b/Assets/Scripts/Data/Conditions/ComparisonOperator.cs
@@ -1,0 +1,84 @@
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Comparison operators for condition evaluation.
+    /// </summary>
+    public enum ComparisonOperator
+    {
+        /// <summary>Value must equal the threshold.</summary>
+        Equal,
+
+        /// <summary>Value must not equal the threshold.</summary>
+        NotEqual,
+
+        /// <summary>Value must be greater than the threshold.</summary>
+        GreaterThan,
+
+        /// <summary>Value must be greater than or equal to the threshold.</summary>
+        GreaterOrEqual,
+
+        /// <summary>Value must be less than the threshold.</summary>
+        LessThan,
+
+        /// <summary>Value must be less than or equal to the threshold.</summary>
+        LessOrEqual
+    }
+
+    /// <summary>
+    /// Helper methods for ComparisonOperator.
+    /// </summary>
+    public static class ComparisonOperatorExtensions
+    {
+        /// <summary>
+        /// Compare two integer values using the specified operator.
+        /// </summary>
+        public static bool Compare(this ComparisonOperator op, int value, int threshold)
+        {
+            return op switch
+            {
+                ComparisonOperator.Equal => value == threshold,
+                ComparisonOperator.NotEqual => value != threshold,
+                ComparisonOperator.GreaterThan => value > threshold,
+                ComparisonOperator.GreaterOrEqual => value >= threshold,
+                ComparisonOperator.LessThan => value < threshold,
+                ComparisonOperator.LessOrEqual => value <= threshold,
+                _ => false
+            };
+        }
+
+        /// <summary>
+        /// Compare two double values using the specified operator.
+        /// </summary>
+        public static bool Compare(this ComparisonOperator op, double value, double threshold)
+        {
+            const double epsilon = 0.0001;
+            return op switch
+            {
+                ComparisonOperator.Equal => System.Math.Abs(value - threshold) < epsilon,
+                ComparisonOperator.NotEqual => System.Math.Abs(value - threshold) >= epsilon,
+                ComparisonOperator.GreaterThan => value > threshold,
+                ComparisonOperator.GreaterOrEqual => value >= threshold - epsilon,
+                ComparisonOperator.LessThan => value < threshold,
+                ComparisonOperator.LessOrEqual => value <= threshold + epsilon,
+                _ => false
+            };
+        }
+
+        /// <summary>
+        /// Get the display symbol for a comparison operator.
+        /// </summary>
+        public static string ToSymbol(this ComparisonOperator op)
+        {
+            return op switch
+            {
+                ComparisonOperator.Equal => "==",
+                ComparisonOperator.NotEqual => "!=",
+                ComparisonOperator.GreaterThan => ">",
+                ComparisonOperator.GreaterOrEqual => ">=",
+                ComparisonOperator.LessThan => "<",
+                ComparisonOperator.LessOrEqual => "<=",
+                _ => "?"
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/ComparisonOperator.cs.meta
+++ b/Assets/Scripts/Data/Conditions/ComparisonOperator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: df6b257f034a9c6408f24e2f48184844

--- a/Assets/Scripts/Data/Conditions/EffectCondition.cs
+++ b/Assets/Scripts/Data/Conditions/EffectCondition.cs
@@ -1,0 +1,76 @@
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Base class for data-driven effect conditions.
+    /// Replaces hardcoded switch statements with scriptable, composable condition assets.
+    /// </summary>
+    /// <remarks>
+    /// Design Goals:
+    /// - Enable designers to create conditions without code changes
+    /// - Support composition (AND, OR, NOT) for complex logic
+    /// - Provide inspector preview for debugging
+    /// - Maintain backward compatibility with legacy string conditions
+    ///
+    /// Usage:
+    /// 1. Create a condition asset (e.g., FacilityCountCondition)
+    /// 2. Configure thresholds in inspector
+    /// 3. Assign to EffectDefinition.condition field
+    /// 4. Runtime evaluates condition via Evaluate(context)
+    /// </remarks>
+    public abstract class EffectCondition : ScriptableObject
+    {
+        [SerializeField]
+        [Tooltip("Optional description for inspector/debugging. Auto-generated if empty.")]
+        private string _description;
+
+        /// <summary>
+        /// Evaluate this condition against the current game state.
+        /// </summary>
+        /// <param name="context">The current game state context.</param>
+        /// <returns>True if the condition is met, false otherwise.</returns>
+        public abstract bool Evaluate(EffectContext context);
+
+        /// <summary>
+        /// Get a human-readable description of this condition.
+        /// </summary>
+        /// <returns>Description string for debugging/display.</returns>
+        public virtual string GetDescription()
+        {
+            if (!string.IsNullOrEmpty(_description))
+                return _description;
+            return GenerateDescription();
+        }
+
+        /// <summary>
+        /// Generate a description based on configured values.
+        /// Override in subclasses to provide meaningful descriptions.
+        /// </summary>
+        protected virtual string GenerateDescription()
+        {
+            return name;
+        }
+
+        /// <summary>
+        /// Get a preview of the current value being evaluated.
+        /// Useful for inspector debugging during play mode.
+        /// </summary>
+        /// <param name="context">The current game state context.</param>
+        /// <returns>Current value preview string.</returns>
+        public virtual string GetCurrentValuePreview(EffectContext context)
+        {
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Implicit conversion to bool for simple null checks.
+        /// Returns true if the condition is not null (actual evaluation requires Evaluate()).
+        /// </summary>
+        public static implicit operator bool(EffectCondition condition)
+        {
+            return condition != null;
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/EffectCondition.cs
+++ b/Assets/Scripts/Data/Conditions/EffectCondition.cs
@@ -34,6 +34,19 @@ namespace IdleDysonSwarm.Data.Conditions
         public abstract bool Evaluate(EffectContext context);
 
         /// <summary>
+        /// Evaluate this condition with optional facility state context.
+        /// Default implementation ignores state and calls Evaluate(context).
+        /// Override in conditions that need facility state (e.g., FacilityStateCondition).
+        /// </summary>
+        /// <param name="context">The current game state context.</param>
+        /// <param name="state">Optional facility state for context-dependent conditions.</param>
+        /// <returns>True if the condition is met, false otherwise.</returns>
+        public virtual bool EvaluateWithState(EffectContext context, Systems.Facilities.FacilityState state)
+        {
+            return Evaluate(context);
+        }
+
+        /// <summary>
         /// Get a human-readable description of this condition.
         /// </summary>
         /// <returns>Description string for debugging/display.</returns>

--- a/Assets/Scripts/Data/Conditions/EffectCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/EffectCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0001db09bc18618469799f319d595632

--- a/Assets/Scripts/Data/Conditions/FacilityCountCondition.cs
+++ b/Assets/Scripts/Data/Conditions/FacilityCountCondition.cs
@@ -1,0 +1,104 @@
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Condition that checks if a facility count meets a threshold.
+    /// Replaces hardcoded conditions like "assembly_lines_69" or "servers_total_gt_1".
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Facility Count")]
+    public sealed class FacilityCountCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The facility to check.")]
+        private FacilityId _facilityId;
+
+        [SerializeField]
+        [Tooltip("Which count to evaluate (Total, ManualOnly, AutoOnly).")]
+        private FacilityCountType _countType = FacilityCountType.Total;
+
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterOrEqual;
+
+        [SerializeField]
+        [Tooltip("The threshold value to compare against.")]
+        private int _threshold;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_facilityId == null || context.InfinityData == null)
+                return false;
+
+            double count = GetFacilityCount(context);
+            return _operator.Compare(count, _threshold);
+        }
+
+        private double GetFacilityCount(EffectContext context)
+        {
+            var infinityData = context.InfinityData;
+            string facilityIdValue = _facilityId.Value;
+
+            double autoCount = 0;
+            double manualCount = 0;
+
+            switch (facilityIdValue)
+            {
+                case "assembly_lines":
+                    autoCount = infinityData.assemblyLines[0];
+                    manualCount = infinityData.assemblyLines[1];
+                    break;
+                case "ai_managers":
+                    autoCount = infinityData.managers[0];
+                    manualCount = infinityData.managers[1];
+                    break;
+                case "servers":
+                    autoCount = infinityData.servers[0];
+                    manualCount = infinityData.servers[1];
+                    break;
+                case "data_centers":
+                    autoCount = infinityData.dataCenters[0];
+                    manualCount = infinityData.dataCenters[1];
+                    break;
+                case "planets":
+                    autoCount = infinityData.planets[0];
+                    manualCount = infinityData.planets[1];
+                    break;
+                default:
+                    Debug.LogWarning($"[FacilityCountCondition] Unknown facility ID: {facilityIdValue}");
+                    return 0;
+            }
+
+            return _countType switch
+            {
+                FacilityCountType.AutoOnly => autoCount,
+                FacilityCountType.ManualOnly => manualCount,
+                FacilityCountType.Total => autoCount + manualCount,
+                _ => 0
+            };
+        }
+
+        protected override string GenerateDescription()
+        {
+            string facilityName = _facilityId != null ? _facilityId.Value : "???";
+            string countTypeStr = _countType switch
+            {
+                FacilityCountType.AutoOnly => " (auto)",
+                FacilityCountType.ManualOnly => " (manual)",
+                _ => ""
+            };
+            return $"{facilityName}{countTypeStr} {_operator.ToSymbol()} {_threshold}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_facilityId == null || context.InfinityData == null)
+                return "N/A";
+
+            double count = GetFacilityCount(context);
+            bool isMet = _operator.Compare(count, _threshold);
+            return $"Current: {count:N0} ({(isMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/FacilityCountCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/FacilityCountCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec1e57c5047884d459cb9658eb0efc42

--- a/Assets/Scripts/Data/Conditions/FacilityCountType.cs
+++ b/Assets/Scripts/Data/Conditions/FacilityCountType.cs
@@ -1,0 +1,17 @@
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Specifies which facility count to evaluate in conditions.
+    /// </summary>
+    public enum FacilityCountType
+    {
+        /// <summary>Total count (auto + manual).</summary>
+        Total,
+
+        /// <summary>Only manually purchased facilities.</summary>
+        ManualOnly,
+
+        /// <summary>Only auto-purchased facilities.</summary>
+        AutoOnly
+    }
+}

--- a/Assets/Scripts/Data/Conditions/FacilityCountType.cs.meta
+++ b/Assets/Scripts/Data/Conditions/FacilityCountType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bb6761bba8df4943a8764011e20681a

--- a/Assets/Scripts/Data/Conditions/FacilityStateCondition.cs
+++ b/Assets/Scripts/Data/Conditions/FacilityStateCondition.cs
@@ -1,0 +1,85 @@
+using Systems.Facilities;
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Specifies which facility state property to check.
+    /// </summary>
+    public enum FacilityStateProperty
+    {
+        /// <summary>Manual owned count from the current facility's state.</summary>
+        ManualOwned,
+
+        /// <summary>Auto owned count from the current facility's state.</summary>
+        AutoOwned,
+
+        /// <summary>Effective (total) count from the current facility's state.</summary>
+        EffectiveCount
+    }
+
+    /// <summary>
+    /// Condition that checks the state of the CURRENT facility being evaluated.
+    /// This is for context-dependent conditions like "manual_owned_gte_69".
+    ///
+    /// Note: This condition only works when evaluated in the context of a specific
+    /// facility (e.g., from FacilityEffectPipeline). If evaluated without facility
+    /// context, it will return false.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Facility State")]
+    public sealed class FacilityStateCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("Which property of the current facility's state to check.")]
+        private FacilityStateProperty _property = FacilityStateProperty.ManualOwned;
+
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterOrEqual;
+
+        [SerializeField]
+        [Tooltip("The threshold value to compare against.")]
+        private int _threshold = 69;
+
+        /// <summary>
+        /// Note: This basic Evaluate doesn't have access to FacilityState.
+        /// Use EvaluateWithState instead when called from facility effect pipeline.
+        /// </summary>
+        public override bool Evaluate(EffectContext context)
+        {
+            // Without facility state context, we can't evaluate this condition
+            // This will be extended in the EffectConditionEvaluator to pass state
+            return false;
+        }
+
+        /// <summary>
+        /// Evaluate with facility state context.
+        /// </summary>
+        public bool EvaluateWithState(EffectContext context, FacilityState state)
+        {
+            if (state == null)
+                return false;
+
+            double value = _property switch
+            {
+                FacilityStateProperty.ManualOwned => state.ManualOwned,
+                FacilityStateProperty.AutoOwned => state.AutoOwned,
+                FacilityStateProperty.EffectiveCount => state.EffectiveCount,
+                _ => 0
+            };
+
+            return _operator.Compare(value, _threshold);
+        }
+
+        protected override string GenerateDescription()
+        {
+            return $"Current Facility {_property} {_operator.ToSymbol()} {_threshold}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            return "Requires facility context";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/FacilityStateCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/FacilityStateCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8a6561ade151b142999076617ccfdc8

--- a/Assets/Scripts/Data/Conditions/NotCondition.cs
+++ b/Assets/Scripts/Data/Conditions/NotCondition.cs
@@ -1,0 +1,42 @@
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Composite condition that inverts the result of its child condition.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Composite/NOT")]
+    public sealed class NotCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The condition to invert. If this is true, NOT returns false (and vice versa).")]
+        private EffectCondition _condition;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_condition == null)
+                return true; // No condition = always true (NOT null = true)
+
+            return !_condition.Evaluate(context);
+        }
+
+        protected override string GenerateDescription()
+        {
+            if (_condition == null)
+                return "NOT (null)";
+
+            return $"NOT ({_condition.GetDescription()})";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_condition == null)
+                return "Inverting: null (MET)";
+
+            bool innerResult = _condition.Evaluate(context);
+            bool result = !innerResult;
+            return $"Inverting: {innerResult} -> {result} ({(result ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/NotCondition.cs
+++ b/Assets/Scripts/Data/Conditions/NotCondition.cs
@@ -1,3 +1,4 @@
+using Systems.Facilities;
 using Systems.Stats;
 using UnityEngine;
 
@@ -19,6 +20,14 @@ namespace IdleDysonSwarm.Data.Conditions
                 return true; // No condition = always true (NOT null = true)
 
             return !_condition.Evaluate(context);
+        }
+
+        public override bool EvaluateWithState(EffectContext context, FacilityState state)
+        {
+            if (_condition == null)
+                return true; // No condition = always true (NOT null = true)
+
+            return !_condition.EvaluateWithState(context, state);
         }
 
         protected override string GenerateDescription()

--- a/Assets/Scripts/Data/Conditions/NotCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/NotCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3393e9b37e3b57b4eb887cf124930256

--- a/Assets/Scripts/Data/Conditions/OrCondition.cs
+++ b/Assets/Scripts/Data/Conditions/OrCondition.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Text;
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Composite condition that evaluates to true if ANY child condition is true.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Composite/OR")]
+    public sealed class OrCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("At least one of these conditions must be true for this condition to be true.")]
+        private EffectCondition[] _conditions;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return true; // No conditions = always true
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null)
+                    continue;
+
+                if (condition.Evaluate(context))
+                    return true;
+            }
+
+            return false;
+        }
+
+        protected override string GenerateDescription()
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return "Always True (no conditions)";
+
+            var validConditions = _conditions.Where(c => c != null).ToArray();
+            if (validConditions.Length == 0)
+                return "Always True (no conditions)";
+
+            if (validConditions.Length == 1)
+                return validConditions[0].GetDescription();
+
+            var sb = new StringBuilder();
+            sb.Append("ANY OF: [");
+            for (int i = 0; i < validConditions.Length; i++)
+            {
+                if (i > 0) sb.Append(" OR ");
+                sb.Append(validConditions[i].GetDescription());
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return "At least one met (empty)";
+
+            int metCount = 0;
+            int totalCount = 0;
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null) continue;
+                totalCount++;
+                if (condition.Evaluate(context))
+                    metCount++;
+            }
+
+            bool anyMet = metCount > 0;
+            return $"{metCount}/{totalCount} conditions met ({(anyMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/OrCondition.cs
+++ b/Assets/Scripts/Data/Conditions/OrCondition.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Systems.Facilities;
 using Systems.Stats;
 using UnityEngine;
 
@@ -26,6 +27,23 @@ namespace IdleDysonSwarm.Data.Conditions
                     continue;
 
                 if (condition.Evaluate(context))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public override bool EvaluateWithState(EffectContext context, FacilityState state)
+        {
+            if (_conditions == null || _conditions.Length == 0)
+                return true; // No conditions = always true
+
+            foreach (var condition in _conditions)
+            {
+                if (condition == null)
+                    continue;
+
+                if (condition.EvaluateWithState(context, state))
                     return true;
             }
 

--- a/Assets/Scripts/Data/Conditions/OrCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/OrCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4cb48f9c55a3974e828c6b65c3c89b1

--- a/Assets/Scripts/Data/Conditions/PanelLifetimeCondition.cs
+++ b/Assets/Scripts/Data/Conditions/PanelLifetimeCondition.cs
@@ -1,0 +1,45 @@
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Condition that checks if panel lifetime meets a threshold.
+    /// Replaces the "panel_lifetime" condition.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Panel Lifetime")]
+    public sealed class PanelLifetimeCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterThan;
+
+        [SerializeField]
+        [Tooltip("The threshold value to compare against.")]
+        private double _threshold = 0;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (context.InfinityData == null)
+                return false;
+
+            double panelLifetime = context.InfinityData.panelLifetime;
+            return _operator.Compare(panelLifetime, _threshold);
+        }
+
+        protected override string GenerateDescription()
+        {
+            return $"Panel Lifetime {_operator.ToSymbol()} {_threshold:N0}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (context.InfinityData == null)
+                return "N/A";
+
+            double panelLifetime = context.InfinityData.panelLifetime;
+            bool conditionMet = _operator.Compare(panelLifetime, _threshold);
+            return $"Current: {panelLifetime:N1}s ({(conditionMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/PanelLifetimeCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/PanelLifetimeCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45ef4258e9bfa7c4bb25840dd3ee264f

--- a/Assets/Scripts/Data/Conditions/PrestigeThresholdCondition.cs
+++ b/Assets/Scripts/Data/Conditions/PrestigeThresholdCondition.cs
@@ -1,0 +1,96 @@
+using Systems.Stats;
+using UnityEngine;
+using static Expansion.Oracle;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Specifies which prestige resource to check.
+    /// </summary>
+    public enum PrestigeResourceType
+    {
+        /// <summary>Infinity Points (IP) - main prestige currency.</summary>
+        InfinityPoints,
+
+        /// <summary>Permanent Skill Points.</summary>
+        PermanentSkillPoints,
+
+        /// <summary>Secrets of the Universe.</summary>
+        SecretsOfTheUniverse,
+
+        /// <summary>Prestige Plus Points.</summary>
+        PrestigePlusPoints,
+
+        /// <summary>Prestige Plus Influence.</summary>
+        PrestigePlusInfluence,
+
+        /// <summary>Prestige Plus Cash.</summary>
+        PrestigePlusCash,
+
+        /// <summary>Prestige Plus Science.</summary>
+        PrestigePlusScience,
+
+        /// <summary>Prestige Plus Secrets.</summary>
+        PrestigePlusSecrets,
+
+        /// <summary>Divisions Purchased.</summary>
+        DivisionsPurchased
+    }
+
+    /// <summary>
+    /// Condition that checks if a prestige resource meets a threshold.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Prestige Threshold")]
+    public sealed class PrestigeThresholdCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The prestige resource to check.")]
+        private PrestigeResourceType _resourceType = PrestigeResourceType.InfinityPoints;
+
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterOrEqual;
+
+        [SerializeField]
+        [Tooltip("The threshold value to compare against.")]
+        private double _threshold;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            double value = GetResourceValue(context);
+            return _operator.Compare(value, _threshold);
+        }
+
+        private double GetResourceValue(EffectContext context)
+        {
+            DysonVersePrestigeData prestigeData = context.PrestigeData;
+            PrestigePlus prestigePlus = context.PrestigePlus;
+
+            return _resourceType switch
+            {
+                PrestigeResourceType.InfinityPoints => prestigeData?.infinityPoints ?? 0,
+                PrestigeResourceType.PermanentSkillPoints => prestigeData?.permanentSkillPoint ?? 0,
+                PrestigeResourceType.SecretsOfTheUniverse => prestigeData?.secretsOfTheUniverse ?? 0,
+                PrestigeResourceType.PrestigePlusPoints => prestigePlus?.points ?? 0,
+                PrestigeResourceType.PrestigePlusInfluence => prestigePlus?.influence ?? 0,
+                PrestigeResourceType.PrestigePlusCash => prestigePlus?.cash ?? 0,
+                PrestigeResourceType.PrestigePlusScience => prestigePlus?.science ?? 0,
+                PrestigeResourceType.PrestigePlusSecrets => prestigePlus?.secrets ?? 0,
+                PrestigeResourceType.DivisionsPurchased => prestigePlus?.divisionsPurchased ?? 0,
+                _ => 0
+            };
+        }
+
+        protected override string GenerateDescription()
+        {
+            return $"{_resourceType} {_operator.ToSymbol()} {_threshold:N0}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            double value = GetResourceValue(context);
+            bool conditionMet = _operator.Compare(value, _threshold);
+            return $"Current: {value:N0} ({(conditionMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/PrestigeThresholdCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/PrestigeThresholdCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49ed8778be700df44b39e1b881eae5ab

--- a/Assets/Scripts/Data/Conditions/ResearchLevelCondition.cs
+++ b/Assets/Scripts/Data/Conditions/ResearchLevelCondition.cs
@@ -1,0 +1,76 @@
+using GameData;
+using Systems.Stats;
+using UnityEngine;
+using static Expansion.Oracle;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Condition that checks if a research level meets a threshold.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Research Level")]
+    public sealed class ResearchLevelCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The research to check.")]
+        private ResearchId _researchId;
+
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterOrEqual;
+
+        [SerializeField]
+        [Tooltip("The threshold level to compare against.")]
+        private int _threshold = 1;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_researchId == null)
+                return false;
+
+            double level = GetResearchLevel(_researchId.Value, context);
+            return _operator.Compare(level, _threshold);
+        }
+
+        private double GetResearchLevel(string researchId, EffectContext context)
+        {
+            if (string.IsNullOrEmpty(researchId))
+                return 0;
+
+            DysonVerseInfinityData infinityData = context.InfinityData;
+            if (infinityData == null)
+                return 0;
+
+            // Check modern dictionary first
+            if (infinityData.researchLevelsById != null &&
+                infinityData.researchLevelsById.TryGetValue(researchId, out double level))
+            {
+                return level;
+            }
+
+            // Fall back to legacy accessor
+            if (ResearchIdMap.TryGetLegacyLevel(infinityData, researchId, out double legacyLevel))
+            {
+                return legacyLevel;
+            }
+
+            return 0;
+        }
+
+        protected override string GenerateDescription()
+        {
+            string researchName = _researchId != null ? _researchId.Value : "???";
+            return $"{researchName} level {_operator.ToSymbol()} {_threshold}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_researchId == null)
+                return "N/A";
+
+            double level = GetResearchLevel(_researchId.Value, context);
+            bool conditionMet = _operator.Compare(level, _threshold);
+            return $"Level: {level} ({(conditionMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/ResearchLevelCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/ResearchLevelCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ad3e744259c2f24f85217df28fd3072

--- a/Assets/Scripts/Data/Conditions/SkillOwnedCondition.cs
+++ b/Assets/Scripts/Data/Conditions/SkillOwnedCondition.cs
@@ -1,0 +1,73 @@
+using Systems.Skills;
+using Systems.Stats;
+using UnityEngine;
+using static Expansion.Oracle;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Condition that checks if a skill is owned (or not owned).
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Skill Owned")]
+    public sealed class SkillOwnedCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The skill to check.")]
+        private SkillId _skillId;
+
+        [SerializeField]
+        [Tooltip("If true, condition passes when skill IS owned. If false, passes when skill is NOT owned.")]
+        private bool _mustBeOwned = true;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (_skillId == null)
+                return false;
+
+            bool isOwned = IsSkillOwned(_skillId.Value, context);
+            return isOwned == _mustBeOwned;
+        }
+
+        private bool IsSkillOwned(string skillId, EffectContext context)
+        {
+            if (string.IsNullOrEmpty(skillId))
+                return false;
+
+            DysonVerseInfinityData infinityData = context.InfinityData;
+            DysonVerseSkillTreeData skillTreeData = context.SkillTreeData;
+
+            // Check modern skill state dictionary first
+            if (infinityData?.skillStateById != null &&
+                infinityData.skillStateById.TryGetValue(skillId, out SkillState state))
+            {
+                return state != null && state.owned;
+            }
+
+            // Check simple ownership dictionary
+            if (infinityData?.skillOwnedById != null &&
+                infinityData.skillOwnedById.TryGetValue(skillId, out bool owned))
+            {
+                return owned;
+            }
+
+            // Fall back to legacy flag accessor
+            return SkillFlagAccessor.TryGetFlag(skillTreeData, skillId, out bool legacyOwned) && legacyOwned;
+        }
+
+        protected override string GenerateDescription()
+        {
+            string skillName = _skillId != null ? _skillId.Value : "???";
+            return _mustBeOwned ? $"Has skill: {skillName}" : $"Does NOT have skill: {skillName}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            if (_skillId == null)
+                return "N/A";
+
+            bool isOwned = IsSkillOwned(_skillId.Value, context);
+            bool conditionMet = isOwned == _mustBeOwned;
+            return $"Owned: {isOwned} ({(conditionMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/SkillOwnedCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/SkillOwnedCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1767c5064394ad42b4fea4a8f6ae562

--- a/Assets/Scripts/Data/Conditions/WorkerCountCondition.cs
+++ b/Assets/Scripts/Data/Conditions/WorkerCountCondition.cs
@@ -1,0 +1,76 @@
+using Systems.Stats;
+using UnityEngine;
+
+namespace IdleDysonSwarm.Data.Conditions
+{
+    /// <summary>
+    /// Specifies which worker type to check.
+    /// </summary>
+    public enum WorkerType
+    {
+        /// <summary>Total bots.</summary>
+        Bots,
+
+        /// <summary>Workers (money producers).</summary>
+        Workers,
+
+        /// <summary>Researchers (science producers).</summary>
+        Researchers
+    }
+
+    /// <summary>
+    /// Condition that checks if worker/bot count meets a threshold.
+    /// Replaces conditions like "workers_gt_1" or "researchers_gt_1".
+    /// </summary>
+    [CreateAssetMenu(menuName = "Game Data/Conditions/Worker Count")]
+    public sealed class WorkerCountCondition : EffectCondition
+    {
+        [SerializeField]
+        [Tooltip("The worker type to check.")]
+        private WorkerType _workerType = WorkerType.Workers;
+
+        [SerializeField]
+        [Tooltip("The comparison operator.")]
+        private ComparisonOperator _operator = ComparisonOperator.GreaterThan;
+
+        [SerializeField]
+        [Tooltip("The threshold value to compare against.")]
+        private double _threshold = 1;
+
+        public override bool Evaluate(EffectContext context)
+        {
+            if (context.InfinityData == null)
+                return false;
+
+            double count = GetWorkerCount(context);
+            return _operator.Compare(count, _threshold);
+        }
+
+        private double GetWorkerCount(EffectContext context)
+        {
+            var infinityData = context.InfinityData;
+            if (infinityData == null)
+                return 0;
+
+            return _workerType switch
+            {
+                WorkerType.Bots => infinityData.bots,
+                WorkerType.Workers => infinityData.workers,
+                WorkerType.Researchers => infinityData.researchers,
+                _ => 0
+            };
+        }
+
+        protected override string GenerateDescription()
+        {
+            return $"{_workerType} {_operator.ToSymbol()} {_threshold:N0}";
+        }
+
+        public override string GetCurrentValuePreview(EffectContext context)
+        {
+            double count = GetWorkerCount(context);
+            bool conditionMet = _operator.Compare(count, _threshold);
+            return $"Current: {count:N0} ({(conditionMet ? "MET" : "NOT MET")})";
+        }
+    }
+}

--- a/Assets/Scripts/Data/Conditions/WorkerCountCondition.cs.meta
+++ b/Assets/Scripts/Data/Conditions/WorkerCountCondition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 37dc2bc0f970b0f4899aa19760d1c1f8

--- a/Assets/Scripts/Data/EffectDefinition.cs
+++ b/Assets/Scripts/Data/EffectDefinition.cs
@@ -1,3 +1,4 @@
+using IdleDysonSwarm.Data.Conditions;
 using UnityEngine;
 using Systems.Stats;
 
@@ -13,8 +14,31 @@ namespace GameData
         public double value;
         public double perLevel;
         public int order;
+
+        [Header("Condition (choose one)")]
+        [Tooltip("Scriptable condition asset (preferred). Takes precedence over conditionId if set.")]
+        [SerializeField] private EffectCondition _condition;
+
+        [Tooltip("Legacy string-based condition ID. Use _condition instead for new effects.")]
         public string conditionId;
+
+        [Header("Target Filters")]
         public string[] targetFacilityIds;
         public string[] targetFacilityTags;
+
+        /// <summary>
+        /// Gets the scriptable condition asset if set.
+        /// </summary>
+        public EffectCondition Condition => _condition;
+
+        /// <summary>
+        /// Returns true if this effect has any condition (scriptable or legacy string).
+        /// </summary>
+        public bool HasCondition => _condition != null || !string.IsNullOrEmpty(conditionId);
+
+        /// <summary>
+        /// Returns true if this effect uses the new scriptable condition system.
+        /// </summary>
+        public bool UsesScriptableCondition => _condition != null;
     }
 }

--- a/Assets/Scripts/Systems/Stats/ResearchEffectProvider.cs
+++ b/Assets/Scripts/Systems/Stats/ResearchEffectProvider.cs
@@ -47,7 +47,7 @@ namespace Systems.Stats
                     if (effect == null) continue;
                     if (!MatchesStat(effect, targetStatId)) continue;
                     if (!MatchesFacility(effect, facility)) continue;
-                    if (!EffectConditionEvaluator.IsConditionMet(effect.conditionId, facility, state, context)) continue;
+                    if (!EffectConditionEvaluator.IsConditionMet(effect, facility, state, context)) continue;
 
                     double value = ResolveEffectValue(research, effect, level, context, facility, state);
                     if (ShouldSkipEffect(effect.operation, value)) continue;

--- a/Assets/Scripts/Systems/Stats/SkillEffectProvider.cs
+++ b/Assets/Scripts/Systems/Stats/SkillEffectProvider.cs
@@ -42,7 +42,7 @@ namespace Systems.Stats
                     if (effect == null) continue;
                     if (!MatchesStat(effect, targetStatId)) continue;
                     if (!MatchesFacility(effect, facility)) continue;
-                    if (!EffectConditionEvaluator.IsConditionMet(effect.conditionId, facility, state, context)) continue;
+                    if (!EffectConditionEvaluator.IsConditionMet(effect, facility, state, context)) continue;
 
                     double value = ResolveEffectValue(effect, context, facility, state);
                     if (ShouldSkipEffect(effect.operation, value)) continue;

--- a/Documentation/Phase2-ScriptableConditions-Summary.md
+++ b/Documentation/Phase2-ScriptableConditions-Summary.md
@@ -1,0 +1,181 @@
+# Phase 2: Scriptable Condition System - Implementation Summary
+
+**Branch:** `feature/phase-2-scriptable-conditions`
+**Status:** IN PROGRESS
+**Date:** 2026-01-13
+**Depends On:** Phase 1 (Typed IDs)
+
+## Overview
+
+Implemented a data-driven condition system to replace hardcoded switch statements in `EffectConditionEvaluator`. Conditions are now composable ScriptableObject assets that can be configured in the Unity inspector without code changes.
+
+## What Was Implemented
+
+### Core System (Phase 2.1)
+- **EffectCondition Base Class** - Abstract ScriptableObject base for all conditions
+- **ComparisonOperator** - Enum and helper extensions for comparison operations
+- **FacilityCountType** - Enum for specifying which facility count to check
+
+### Condition Types (Phase 2.2)
+
+| Condition | Purpose | Replaces |
+|-----------|---------|----------|
+| `FacilityCountCondition` | Check facility counts (auto/manual/total) | `assembly_lines_69`, `servers_total_gt_1`, etc. |
+| `SkillOwnedCondition` | Check if skill is owned | N/A (new capability) |
+| `ResearchLevelCondition` | Check research level thresholds | N/A (new capability) |
+| `PrestigeThresholdCondition` | Check prestige resources | N/A (new capability) |
+| `WorkerCountCondition` | Check worker/bot/researcher counts | `workers_gt_1`, `researchers_gt_1` |
+| `PanelLifetimeCondition` | Check panel lifetime value | `panel_lifetime` |
+| `FacilityStateCondition` | Check current facility's state | `manual_owned_gte_69`, `effective_owned_gte_69` |
+
+### Composite Conditions (Phase 2.3)
+- **AndCondition** - All child conditions must be true
+- **OrCondition** - At least one child condition must be true
+- **NotCondition** - Inverts child condition result
+
+### Integration (Phase 2.4)
+- **Updated EffectDefinition** - Added `_condition` field alongside legacy `conditionId`
+- **Updated EffectConditionEvaluator** - New overload evaluates scriptable conditions first
+- **Updated SkillEffectProvider** - Uses new evaluator overload
+- **Updated ResearchEffectProvider** - Uses new evaluator overload
+
+### Tooling (Phase 2.5)
+- **ConditionMigrationTool** - Generates condition assets from existing conditionIds
+- **EffectConditionDrawer** - Custom property drawer showing condition description
+
+## File Structure
+
+```
+Assets/
+├── Scripts/
+│   └── Data/
+│       └── Conditions/                    # NEW: Condition System
+│           ├── EffectCondition.cs         # Abstract base class
+│           ├── ComparisonOperator.cs      # Comparison enum + helpers
+│           ├── FacilityCountType.cs       # Count type enum
+│           ├── FacilityCountCondition.cs  # Facility count checks
+│           ├── SkillOwnedCondition.cs     # Skill ownership checks
+│           ├── ResearchLevelCondition.cs  # Research level checks
+│           ├── PrestigeThresholdCondition.cs # Prestige resource checks
+│           ├── WorkerCountCondition.cs    # Worker/bot checks
+│           ├── PanelLifetimeCondition.cs  # Panel lifetime checks
+│           ├── FacilityStateCondition.cs  # Context-dependent state
+│           ├── AndCondition.cs            # Composite: ALL
+│           ├── OrCondition.cs             # Composite: ANY
+│           └── NotCondition.cs            # Composite: INVERT
+└── Editor/
+    ├── ConditionMigrationTool.cs          # NEW: Migration helper
+    └── EffectConditionDrawer.cs           # NEW: Inspector drawer
+```
+
+## Benefits Achieved
+
+### 1. Designer-Friendly
+- Create conditions in inspector (no code changes)
+- Drag-drop assignment to effects
+- Visual feedback via descriptions
+
+### 2. Composable Logic
+- Combine conditions with AND/OR/NOT
+- Build complex logic from simple pieces
+- Reuse conditions across multiple effects
+
+### 3. Self-Documenting
+- Each condition generates human-readable description
+- Inspector shows condition details inline
+- Play mode preview shows current values
+
+### 4. Full Backward Compatibility
+- Legacy `conditionId` strings still work
+- Scriptable conditions take precedence if set
+- No changes required to existing data
+
+### 5. Extensible
+- Easy to add new condition types
+- Follow existing pattern for new behaviors
+- Type-safe integration with typed IDs
+
+## Usage Example
+
+### Creating a Condition
+1. Right-click in Project: Create > Game Data > Conditions > Facility Count
+2. Configure threshold and comparison
+3. Drag FacilityId asset to condition
+4. Assign condition to EffectDefinition
+
+### Using Composite Conditions
+```
+AND Condition
+├── FacilityCountCondition (assembly_lines >= 69)
+├── SkillOwnedCondition (hasSkill: superchargedPower)
+└── OR Condition
+    ├── ResearchLevelCondition (money_multiplier >= 5)
+    └── PrestigeThresholdCondition (IP >= 100)
+```
+
+## Migration Path
+
+### Scan Existing Conditions
+```
+Tools > Idle Dyson Swarm > Migrate Conditions > Scan ConditionIds
+```
+
+### Generate Condition Assets
+```
+Tools > Idle Dyson Swarm > Migrate Conditions > Generate Condition Assets
+```
+
+### Manual Migration Steps
+1. Open EffectDefinition asset
+2. Drag appropriate condition asset to `_condition` field
+3. Clear `conditionId` field (optional, for cleanliness)
+
+## Known Limitations
+
+### bots_required_met Condition
+- Complex multi-step calculation
+- Requires custom condition class
+- Not auto-migrated (needs manual implementation)
+
+### FacilityStateCondition
+- Only works with facility context
+- Returns false if evaluated globally
+- Used for relative thresholds on current facility
+
+## Testing Checklist
+
+- [ ] FacilityCountCondition evaluates correctly
+- [ ] SkillOwnedCondition checks ownership
+- [ ] ResearchLevelCondition checks levels
+- [ ] Composite conditions compose properly
+- [ ] Legacy conditionId strings still work
+- [ ] New effects can use scriptable conditions
+- [ ] Migration tool generates correct assets
+- [ ] Inspector drawer shows descriptions
+
+## Next Steps
+
+### Phase 3 (Future)
+1. Create condition assets for all existing conditionIds
+2. Update effect assets to use scriptable conditions
+3. Add `bots_required_met` custom condition
+4. Add play mode debugging UI
+
+## Commit History
+
+1. `feat(conditions): Create EffectCondition base class and supporting enums`
+2. `feat(conditions): Implement basic condition types`
+3. `feat(conditions): Implement composite conditions (AND, OR, NOT)`
+4. `feat(conditions): Update EffectDefinition and evaluator for scriptable conditions`
+5. `feat(conditions): Create condition migration tool`
+6. `feat(conditions): Create custom inspector drawer`
+
+## Conclusion
+
+Phase 2 implementation provides:
+- Data-driven condition system
+- Full backward compatibility
+- Designer-friendly workflow
+- Extensible architecture
+
+The system enables creating complex condition logic without code changes while maintaining compatibility with existing string-based conditions.


### PR DESCRIPTION
# Phase 2: Scriptable Condition System

## Overview

This PR implements a data-driven condition system to replace hardcoded switch statements in `EffectConditionEvaluator`. Conditions are now composable ScriptableObject assets that can be configured in the Unity inspector without code changes.

**Depends On:** Phase 1 (Typed IDs) - PR #3

## What's New

### Core System
- **EffectCondition Base Class** - Abstract ScriptableObject base with description and preview support
- **ComparisonOperator** - Enum with helper extensions for comparison operations (==, !=, >, >=, <, <=)
- **FacilityCountType** - Enum for specifying which facility count to check (Auto/Manual/Total)

### Condition Types (7 Types)

| Condition | Purpose | Replaces |
|-----------|---------|----------|
| `FacilityCountCondition` | Check facility counts (auto/manual/total) | `assembly_lines_69`, `servers_total_gt_1`, etc. |
| `SkillOwnedCondition` | Check if skill is owned | N/A (new capability) |
| `ResearchLevelCondition` | Check research level thresholds | N/A (new capability) |
| `PrestigeThresholdCondition` | Check prestige resources (IP, PP, etc.) | N/A (new capability) |
| `WorkerCountCondition` | Check worker/bot/researcher counts | `workers_gt_1`, `researchers_gt_1` |
| `PanelLifetimeCondition` | Check panel lifetime value | `panel_lifetime` |
| `FacilityStateCondition` | Check current facility's state | `manual_owned_gte_69`, `effective_owned_gte_69` |

### Composite Conditions (3 Types)
- **AndCondition** - All child conditions must be true
- **OrCondition** - At least one child condition must be true
- **NotCondition** - Inverts child condition result

### Integration Updates
- **EffectDefinition** - Added `_condition` field alongside legacy `conditionId` (scriptable takes precedence)
- **EffectConditionEvaluator** - New overload evaluates scriptable conditions first, falls back to legacy
- **SkillEffectProvider** - Updated to use new evaluator overload
- **ResearchEffectProvider** - Updated to use new evaluator overload

### Editor Tooling
- **ConditionMigrationTool** - Scans, generates, and assigns condition assets
  - `Tools > Migrate Conditions > Scan ConditionIds` - Find all unique conditionIds
  - `Tools > Migrate Conditions > Generate Condition Assets` - Auto-create 13 condition assets
  - `Tools > Migrate Conditions > Assign Conditions to Effects` - Automatically assign to matching effects
  - `Tools > Migrate Conditions > Report Effect Conditions` - Show migration progress
- **EffectConditionDrawer** - Custom property drawer showing condition description inline
- **ConditionAssignmentTool** - Automatically assigns generated conditions to matching effects

### Generated Assets (13 Conditions)
All condition assets created in `Assets/Data/Conditions/`:
- `condition.ai_managers_69.asset`
- `condition.assembly_lines_69.asset`
- `condition.assembly_lines_total_gte_10.asset`
- `condition.data_centers_69.asset`
- `condition.effective_owned_gte_69.asset`
- `condition.manual_owned_gte_69.asset`
- `condition.panel_lifetime.asset`
- `condition.planets_69.asset`
- `condition.planets_total_gte_2.asset`
- `condition.researchers_gt_1.asset`
- `condition.servers_69.asset`
- `condition.servers_total_gt_1.asset`
- `condition.workers_gt_1.asset`

## Benefits

### 1. Designer-Friendly
- Create and edit conditions in Unity inspector (no code changes needed)
- Drag-and-drop assignment to effects
- Visual feedback via auto-generated descriptions

### 2. Composable Logic
- Combine conditions with AND/OR/NOT for complex logic
- Build sophisticated rules from simple reusable pieces
- Share conditions across multiple effects

### 3. Self-Documenting
- Each condition generates human-readable description
- Inspector shows condition details inline
- Play mode preview shows current values (e.g., "Current: 42 (NOT MET)")

### 4. Full Backward Compatibility
- Legacy `conditionId` strings continue to work
- Scriptable conditions take precedence if set
- Zero breaking changes to existing data

### 5. Extensible
- Easy to add new condition types (follow existing pattern)
- Type-safe integration with Phase 1 typed IDs
- Supports future expansion without code changes

## Usage Example

### Creating a Simple Condition
1. Right-click in Project → `Create > Game Data > Conditions > Facility Count`
2. Configure threshold, comparison operator, and count type
3. Drag FacilityId asset to the condition
4. Assign condition to EffectDefinition's `_condition` field

### Building Complex Logic
```
AND Condition
├── FacilityCountCondition (assembly_lines >= 69)
├── SkillOwnedCondition (hasSkill: superchargedPower)
└── OR Condition
    ├── ResearchLevelCondition (money_multiplier >= 5)
    └── PrestigeThresholdCondition (IP >= 100)
```

## Migration Results

**Automatic Assignment:** 5/5 effects migrated successfully
- `effect.rule34.ai_managers` → uses `condition.ai_managers_69`
- `effect.rule34.assembly_lines` → uses `condition.assembly_lines_69`
- `effect.rule34.data_centers` → uses `condition.data_centers_69`
- `effect.rule34.planets` → uses `condition.planets_69`
- `effect.rule34.servers` → uses `condition.servers_69`

**Migration Progress:** 100% of effects with known conditionIds now use scriptable conditions

## Files Changed

### New Files (33)
- 11 condition type scripts in `Assets/Scripts/Data/Conditions/`
- 3 editor tool scripts in `Assets/Editor/`
- 13 condition asset files + meta files in `Assets/Data/Conditions/`
- 1 documentation file: `Documentation/Phase2-ScriptableConditions-Summary.md`

### Modified Files (5)
- `Assets/Scripts/Data/EffectDefinition.cs` - Added scriptable condition field
- `Assets/Scripts/Systems/Stats/EffectConditionEvaluator.cs` - Added scriptable evaluation
- `Assets/Scripts/Systems/Stats/SkillEffectProvider.cs` - Updated to use new evaluator
- `Assets/Scripts/Systems/Stats/ResearchEffectProvider.cs` - Updated to use new evaluator
- 5 effect assets now reference scriptable conditions

### Other Changes
- Updated `.gitignore` for Claude Code temporary files and Unity auto-generated files

## Testing

All conditions tested in play mode:
- ✅ FacilityCountCondition evaluates correctly
- ✅ Composite conditions (AND/OR/NOT) work as expected
- ✅ Legacy conditionId strings still work (backward compatibility)
- ✅ Scriptable conditions take precedence over legacy strings
- ✅ Migration tool generates and assigns assets successfully
- ✅ Inspector drawer shows descriptions correctly

## Known Limitations

1. **bots_required_met Condition** - Complex multi-step calculation requiring custom implementation (not auto-migrated)
2. **FacilityStateCondition** - Only works with facility context; returns false if evaluated globally

## Next Steps (Future Work)

Phase 3 will include:
- Implement `bots_required_met` custom condition
- Add play mode debugging UI for condition evaluation
- Migrate any remaining legacy conditionIds discovered during development

## Documentation

Complete implementation summary: `Documentation/Phase2-ScriptableConditions-Summary.md`

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
