### PR TITLE
fix: Add missing UI folder meta file

### DIFF
--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73f4fd312388cd043865e8c5bf297bd9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Adds the `Assets/Scripts/UI.meta` file that was missed when creating the UI/Theme folder structure in PR #11

## Testing
- [x] Code compiles without errors
- [x] Unity recognizes the folder structure correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)