### PR TITLE
fix: Get fill bar from child instead of parent

### DIFF
--- a/Assets/Scripts/User Interface/InfinityPanelManager.cs
+++ b/Assets/Scripts/User Interface/InfinityPanelManager.cs
@@ -40,8 +40,9 @@ public class InfinityPanelManager : MonoBehaviour
 
     private void Awake()
     {
-        if (_infinityFillObject != null)
-            _infinityFill = _infinityFillObject.GetComponent<SlicedFilledImage>();
+        // Get the Fill child's SlicedFilledImage, not the parent background's
+        if (_infinityFillObject != null && _infinityFillObject.transform.childCount > 0)
+            _infinityFill = _infinityFillObject.transform.GetChild(0).GetComponent<SlicedFilledImage>();
         if (_infinityTextObject != null)
             _infinityText = _infinityTextObject.GetComponent<TMP_Text>();
         if (_infinityMenuButtonObject != null)

--- a/Assets/Scripts/User Interface/PrestigePanelManager.cs
+++ b/Assets/Scripts/User Interface/PrestigePanelManager.cs
@@ -34,8 +34,9 @@ public class PrestigePanelManager : MonoBehaviour
 
     private void Awake()
     {
-        if (_prestigeFillObject != null)
-            _prestigeFill = _prestigeFillObject.GetComponent<SlicedFilledImage>();
+        // Get the Fill child's SlicedFilledImage, not the parent background's
+        if (_prestigeFillObject != null && _prestigeFillObject.transform.childCount > 0)
+            _prestigeFill = _prestigeFillObject.transform.GetChild(0).GetComponent<SlicedFilledImage>();
         if (_prestigeTextObject != null)
             _prestigeText = _prestigeTextObject.GetComponent<TMP_Text>();
         if (_prestigeMenuButtonObject != null)


### PR DESCRIPTION
The SlicedFillBackground has a child Fill that contains the actual fill bar component. GetComponent was returning the parent's SlicedFilledImage (always 1.0) instead of the child's.

Changed to use transform.GetChild(0).GetComponent to explicitly target the Fill child object.