### PR TITLE
feat: Facility breakdown improvements and cleanup

### DIFF
--- a/.claude/skills/unity-mcp/SKILL.md
+++ b/.claude/skills/unity-mcp/SKILL.md
@@ -65,8 +65,16 @@ This call will:
 
 **DO NOT** call this multiple times - one call handles everything.
 
-### 3. Check Console AFTER Refresh Completes
-Only after the refresh call returns, check for errors:
+### 3. WAIT After Refresh Completes (CRITICAL)
+**After `refresh_unity` returns, wait 5-10 seconds before making ANY other MCP calls.**
+
+Unity may still be finalizing internal state even after the refresh call returns. Making MCP calls too quickly can cause:
+- Refreshing during a refresh (causes errors)
+- Stale or incomplete results
+- Connection issues
+
+### 4. Check Console AFTER Waiting
+Only after waiting 5-10 seconds, check for errors:
 
 ```
 read_console(action="get", types=["error", "warning"])
@@ -89,10 +97,11 @@ Edit script...
 [Wait 2-3 seconds for Unity to detect change]
 refresh_unity(scope="scripts", compile="request", wait_for_ready=true)
 [This blocks until compilation is complete]
+[Wait 5-10 seconds after refresh returns]
 read_console(action="get", types=["error", "warning"])
 ```
 
-### 4. If Connection Times Out
+### 5. If Connection Times Out
 Sometimes the refresh call may timeout if compilation takes too long. In this case:
 1. Wait a few seconds
 2. Check console directly: `read_console(action="get", types=["error"])`
@@ -382,6 +391,7 @@ set_active_instance(instance="ProjectName@hash")
 
 **DON'T:**
 - Make changes while Unity is compiling
+- Make MCP calls immediately after refresh (wait 5-10 seconds)
 - Use large page sizes (causes token bloat)
 - Enable previews unless needed
 - Proceed without checking for errors
@@ -410,11 +420,16 @@ set_active_instance(instance="ProjectName@hash")
    → This blocks until compilation is complete
    → DO NOT call multiple times
 
-6. Check console for results
+6. WAIT after refresh completes (CRITICAL)
+   → Pause 5-10 seconds after refresh returns
+   → Unity may still be finalizing internal state
+   → Making MCP calls too soon causes "refresh during refresh" errors
+
+7. Check console for results
    → read_console(action="get", types=["error", "warning"])
    → If errors exist, fix them and repeat from step 2
 
-7. Proceed to next task
+8. Proceed to next task
    → Only after confirming no errors
 ```
 
@@ -422,6 +437,7 @@ set_active_instance(instance="ProjectName@hash")
 - ONE refresh call, not multiple
 - Wait for Unity to detect file changes before refreshing
 - The `wait_for_ready=true` parameter handles the waiting for you
-- Check console AFTER refresh completes, not during
+- **WAIT 5-10 seconds after refresh returns before any other MCP calls**
+- Check console AFTER waiting, not immediately after refresh
 
 This workflow ensures safe, reliable Unity development via MCP.

--- a/Assets/Prefabs/Buildings/Building.prefab
+++ b/Assets/Prefabs/Buildings/Building.prefab
@@ -1,5 +1,61 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &729041328147882157
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 361113782652836614}
+  - component: {fileID: 6211616991915871592}
+  m_Layer: 5
+  m_Name: flexspace
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &361113782652836614
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729041328147882157}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1816107200081283724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6211616991915871592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729041328147882157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: 9999
+  m_LayoutPriority: 1
 --- !u!1 &749043298082788064
 GameObject:
   m_ObjectHideFlags: 0
@@ -286,7 +342,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 18.2
+  m_fontSize: 20
   m_fontSizeBase: 26
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -463,6 +519,143 @@ MonoBehaviour:
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1728316157195397048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 108238780102019224}
+  - component: {fileID: 2332428143418711645}
+  - component: {fileID: 7874857979336747877}
+  m_Layer: 5
+  m_Name: amount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &108238780102019224
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728316157195397048}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8554333476264447631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2332428143418711645
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728316157195397048}
+  m_CullTransparentMesh: 1
+--- !u!114 &7874857979336747877
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728316157195397048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_sharedMaterial: {fileID: -6419816020481481130, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 30}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -1325,6 +1518,7 @@ RectTransform:
   - {fileID: 5750270055842149971}
   - {fileID: 2253853159162163484}
   - {fileID: 6753149733383523128}
+  - {fileID: 361113782652836614}
   m_Father: {fileID: 2063004942282404786}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1571,7 +1765,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: -1
-  m_MinHeight: -1
+  m_MinHeight: 125
   m_PreferredWidth: -1
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
@@ -1786,6 +1980,254 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &6804365571358682885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8554333476264447631}
+  - component: {fileID: 9157744047625624593}
+  - component: {fileID: 5229520215567339142}
+  - component: {fileID: 288058007971429249}
+  - component: {fileID: 4070433838721029685}
+  m_Layer: 5
+  m_Name: BreakdownButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8554333476264447631
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6804365571358682885}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 7990001533698560024}
+  - {fileID: 108238780102019224}
+  m_Father: {fileID: 806418741097828122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9157744047625624593
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6804365571358682885}
+  m_CullTransparentMesh: 1
+--- !u!114 &5229520215567339142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6804365571358682885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 141109fb25f0083469e71ce8cb3e75c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+  m_DrawShape: 3
+  m_ImageType: 0
+  m_MaterialMode: 0
+  m_StrokeWidth: 0
+  m_OutlineWidth: 1
+  m_OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+  m_FalloffDistance: 0
+  m_ConstrainRotation: 1
+  m_ShapeRotation: 0
+  m_FlipHorizontal: 0
+  m_FlipVertical: 0
+  m_Triangle:
+    m_CornerRadius: {x: 0, y: 0, z: 0}
+    m_UniformCornerRadius: 0
+  m_Rectangle:
+    m_CornerRadius: {x: 8, y: 8, z: 8, w: 8}
+    m_UniformCornerRadius: 1
+  m_ChamferBox:
+    m_ChamferSize: 0
+  m_Parallelogram:
+    m_Skew: 0
+    m_CornerRadius: 0
+  m_Circle:
+    m_Radius: 0
+    m_FitRadius: 0
+  m_Pentagon:
+    m_CornerRadius: {x: 0, y: 0, z: 0, w: 0}
+    m_UniformCornerRadius: 0
+    m_TipRadius: 0.001
+    m_TipSize: 1
+  m_Hexagon:
+    m_CornerRadius: {x: 1, y: 1, z: 1, w: 1}
+    m_UniformCornerRadius: 0
+    m_TipSize: {x: 1, y: 1}
+    m_UniformTipSize: 0
+    m_TipRadius: {x: 1, y: 1}
+    m_UniformTipRadius: 0
+  m_NStarPolygon:
+    m_SideCount: 3
+    m_Inset: 2
+    m_CornerRadius: 0
+    m_Offset: {x: 0, y: 0}
+  m_GradientEffect:
+    m_Enabled: 1
+    m_GradientType: 0
+    m_Gradient:
+      serializedVersion: 2
+      key0: {r: 0.9165769, g: 0.759, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    m_CornerGradientColors:
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    m_Rotation: 135
+--- !u!114 &288058007971429249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6804365571358682885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.81960785, g: 0.7137255, b: 0.84313726, a: 1}
+    m_HighlightedColor: {r: 0.81960785, g: 0.7137255, b: 0.84313726, a: 1}
+    m_PressedColor: {r: 0.66630733, g: 0.6113208, b: 0.6792453, a: 1}
+    m_SelectedColor: {r: 0.81960785, g: 0.7137255, b: 0.84313726, a: 1}
+    m_DisabledColor: {r: 0.5088462, g: 0.37730768, b: 0.54, a: 1}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5229520215567339142}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: UnityEngine.AudioSource, UnityEngine
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: DataCenterManager, Assembly-CSharp
+        m_MethodName: PurchaseDataCenter
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4070433838721029685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6804365571358682885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 90
+  m_MinHeight: 30
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &6930875700163159890
 GameObject:
   m_ObjectHideFlags: 0
@@ -1871,6 +2313,143 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &7398315104539765956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7990001533698560024}
+  - component: {fileID: 7243093487105370814}
+  - component: {fileID: 6503571982945100290}
+  m_Layer: 5
+  m_Name: Cost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7990001533698560024
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7398315104539765956}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8554333476264447631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7243093487105370814
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7398315104539765956}
+  m_CullTransparentMesh: 1
+--- !u!114 &6503571982945100290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7398315104539765956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Details
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_sharedMaterial: {fileID: -6419816020481481130, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7410268903883212597
 GameObject:
   m_ObjectHideFlags: 0
@@ -2032,6 +2611,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 49988052059480341}
+  - {fileID: 8554333476264447631}
   m_Father: {fileID: 1342384333310584655}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2057,7 +2637,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 0
-  m_Spacing: 0
+  m_Spacing: 6
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1

--- a/Assets/Prefabs/Buildings/Infinity Variant.prefab
+++ b/Assets/Prefabs/Buildings/Infinity Variant.prefab
@@ -32,6 +32,22 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 806418741097828122, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -228,6 +244,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4954428224332451645, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_MinHeight
+      value: 125
+      objectReference: {fileID: 0}
     - target: {fileID: 4972459859932635571, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_Name
       value: Infinity Variant
@@ -308,13 +328,17 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6804365571358682885, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6837311970100268387, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_text
       value: Secret of the Universe
       objectReference: {fileID: 0}
     - target: {fileID: 6837311970100268387, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_fontSize
-      value: 20
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 7210030659101798083, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_Interactable
@@ -475,6 +499,30 @@ PrefabInstance:
 
         You manage to reveal one of the
         letters..'
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 170
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -71
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Buildings/Research Variant.prefab
+++ b/Assets/Prefabs/Buildings/Research Variant.prefab
@@ -32,6 +32,22 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 361113782652836614, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 806418741097828122, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -196,6 +212,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4954428224332451645, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_MinHeight
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 4972459859932635571, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_Name
       value: Research Variant
@@ -276,13 +296,17 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6804365571358682885, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6837311970100268387, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_text
       value: Science boosts <color=#00E1FF>23
       objectReference: {fileID: 0}
     - target: {fileID: 6837311970100268387, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_fontSize
-      value: 20
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 7210030659101798083, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
@@ -448,6 +472,30 @@ PrefabInstance:
     - target: {fileID: 8104893589352204411, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
       propertyPath: m_fontSizeBase
       value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 170
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554333476264447631, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -71
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Assets/Scripts/Systems/Facilities/FacilityPresenter.cs
+++ b/Assets/Scripts/Systems/Facilities/FacilityPresenter.cs
@@ -11,6 +11,16 @@ namespace Systems.Facilities
 
         private void Start()
         {
+            // Auto-find breakdown button if not assigned in inspector
+            if (breakdownButton == null)
+            {
+                var buttonTransform = transform.Find("Container/Content/Right/Button_Right/BreakdownButton");
+                if (buttonTransform != null)
+                {
+                    breakdownButton = buttonTransform.GetComponent<Button>();
+                }
+            }
+
             if (breakdownButton != null)
             {
                 breakdownButton.onClick.AddListener(ShowBreakdown);

--- a/Assets/Scripts/Systems/GameManager.cs
+++ b/Assets/Scripts/Systems/GameManager.cs
@@ -37,12 +37,6 @@ public class GameManager : MonoBehaviour
 
     [SerializeField] private GameObject[] infinityButton;
 
-    [Space(10), SerializeField] private GameObject planetProductionDisplay;
-    [SerializeField] private TMP_Text totalPlanetsProduction;
-    [SerializeField] private GameObject dataCenterProductionDisplay;
-    [SerializeField] private TMP_Text totalDataCenterText;
-    [SerializeField] private GameObject serverProductionDisplay;
-    [SerializeField] private TMP_Text totalServerProduction;
 
 
     [Header("ReturnScreen"), SerializeField]
@@ -619,22 +613,6 @@ public class GameManager : MonoBehaviour
                 runAge.text = $"Run time: {CalcUtils.FormatTimeLarge(seconds)}";
             }
 
-//serverProduction
-        bool coldFusion = skillTreeData.rudimentarySingularity && infinityData.managers[0] + infinityData.managers[1] > 0;
-        serverProductionDisplay.SetActive(coldFusion);
-
-        /*coldFusionText.gameObject.SetActive(coldFusion);
-        if (skillTreeData.rudimentarySingularity)
-            coldFusionText.text =
-                $"Rudimentary Singularity <color=#FFA45E>+{CalcUtils.FormatNumber(infinityData.rudimentrySingularityProduction)} </color>";*/
-
-        totalServerProduction.text =
-            $"Server Production <color=#FFA45E>+{CalcUtils.FormatNumber(infinityData.rudimentrySingularityProduction)}";
-//planetsProduction
-        bool scientificPlanetsActive = infinityData.researchers > 1 && skillTreeData.scientificPlanets;
-        bool displayPlanetProduction =
-            scientificPlanetsActive || skillTreeData.stellarSacrifices || skillTreeData.planetAssembly || skillTreeData.shellWorlds;
-        planetProductionDisplay.SetActive(displayPlanetProduction);
 
         string planetProductionDetailText = "";
         bool addPlanetLineBreak = false;
@@ -678,12 +656,6 @@ public class GameManager : MonoBehaviour
         }
 
         /*planetProductionText.text = planetProductionDetailText;*/
-        totalPlanetsProduction.text =
-            $"Planet Production <color=#FFA45E>+{CalcUtils.FormatNumber(infinityData.totalPlanetProduction)}";
-//DataCenterProduction
-        bool dataCenterProductionActive = infinityData.workers > 1 && skillTreeData.pocketDimensions || skillTreeData.pocketProtectors;
-
-        dataCenterProductionDisplay.SetActive(dataCenterProductionActive);
 
 
         string dataCenterProductionDetailText = "";
@@ -751,8 +723,6 @@ public class GameManager : MonoBehaviour
 
 
         /*pocketDimensionsText.text = dataCenterProductionDetailText;*/
-        totalDataCenterText.text =
-            $"Data Center Production <color=#FFA45E>+{CalcUtils.FormatNumber(infinityData.pocketDimensionsProduction)}";
 
         string skillTimersDisplayText = "";
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,7 @@ public bool TryGetFacility(string id, out FacilityDefinition definition)
 3. **Feature parity required** - Refactors must not break existing functionality
 4. **No broken saves** - Save compatibility must be verified before merging
 5. **PR for every merge** - All changes reach main through pull requests
+6. **NEVER use `git reset --hard` without asking** - This command destroys uncommitted changes permanently. Always ask the user for confirmation before running any destructive git commands (`reset --hard`, `clean -fd`, `checkout .`, etc.)
 
 ### Branch Naming
 

--- a/tmpclaude-03e9-cwd
+++ b/tmpclaude-03e9-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-0751-cwd
+++ b/tmpclaude-0751-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-082c-cwd
+++ b/tmpclaude-082c-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-0fae-cwd
+++ b/tmpclaude-0fae-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-11c1-cwd
+++ b/tmpclaude-11c1-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-1af6-cwd
+++ b/tmpclaude-1af6-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-1e7a-cwd
+++ b/tmpclaude-1e7a-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2177-cwd
+++ b/tmpclaude-2177-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2889-cwd
+++ b/tmpclaude-2889-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2940-cwd
+++ b/tmpclaude-2940-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2a03-cwd
+++ b/tmpclaude-2a03-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2c2e-cwd
+++ b/tmpclaude-2c2e-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-2c80-cwd
+++ b/tmpclaude-2c80-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-3186-cwd
+++ b/tmpclaude-3186-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-344d-cwd
+++ b/tmpclaude-344d-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-39e3-cwd
+++ b/tmpclaude-39e3-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-43a2-cwd
+++ b/tmpclaude-43a2-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-45e2-cwd
+++ b/tmpclaude-45e2-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-4601-cwd
+++ b/tmpclaude-4601-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-4b90-cwd
+++ b/tmpclaude-4b90-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-4e89-cwd
+++ b/tmpclaude-4e89-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-4ef5-cwd
+++ b/tmpclaude-4ef5-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-509c-cwd
+++ b/tmpclaude-509c-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-5250-cwd
+++ b/tmpclaude-5250-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-530a-cwd
+++ b/tmpclaude-530a-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-543d-cwd
+++ b/tmpclaude-543d-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-5aed-cwd
+++ b/tmpclaude-5aed-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-5ce6-cwd
+++ b/tmpclaude-5ce6-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-6001-cwd
+++ b/tmpclaude-6001-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-6913-cwd
+++ b/tmpclaude-6913-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-6991-cwd
+++ b/tmpclaude-6991-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-7bd0-cwd
+++ b/tmpclaude-7bd0-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-827d-cwd
+++ b/tmpclaude-827d-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-8924-cwd
+++ b/tmpclaude-8924-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-8c12-cwd
+++ b/tmpclaude-8c12-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-925a-cwd
+++ b/tmpclaude-925a-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-94e9-cwd
+++ b/tmpclaude-94e9-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-967e-cwd
+++ b/tmpclaude-967e-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-98e4-cwd
+++ b/tmpclaude-98e4-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-9e42-cwd
+++ b/tmpclaude-9e42-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-a523-cwd
+++ b/tmpclaude-a523-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-ac6b-cwd
+++ b/tmpclaude-ac6b-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-af51-cwd
+++ b/tmpclaude-af51-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-b6ab-cwd
+++ b/tmpclaude-b6ab-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-c073-cwd
+++ b/tmpclaude-c073-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-d6f3-cwd
+++ b/tmpclaude-d6f3-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-daa6-cwd
+++ b/tmpclaude-daa6-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-ddcf-cwd
+++ b/tmpclaude-ddcf-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-e734-cwd
+++ b/tmpclaude-e734-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-ea99-cwd
+++ b/tmpclaude-ea99-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-ef3b-cwd
+++ b/tmpclaude-ef3b-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-efef-cwd
+++ b/tmpclaude-efef-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-f370-cwd
+++ b/tmpclaude-f370-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-f5b5-cwd
+++ b/tmpclaude-f5b5-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-fe9c-cwd
+++ b/tmpclaude-fe9c-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm

--- a/tmpclaude-fec1-cwd
+++ b/tmpclaude-fec1-cwd
@@ -1,1 +1,0 @@
-/c/Users/mattr/Documents/Unity/Projects/Idle Dyson Swarm


### PR DESCRIPTION
## Summary
- Enhanced facility breakdown popup with colored output, symbols for operations, and 10Hz auto-refresh
- Auto-wire breakdown buttons in FacilityPresenter via Transform.Find
- Remove redundant production text displays (Planet Production, Data Center Production, Server Production) from GameManager - now shown in Details breakdown
- Remove tmpclaude temp files from repository
- Add git safety rule to CLAUDE.md for destructive commands
- Update Unity MCP skill documentation with refresh wait guidance

Generated with [Claude Code](https://claude.com/claude-code)