### PR TITLE
fix: Phase 0 - SpaceAgeManager bug fixes

### DIFF
--- a/Assets/Scripts/Expansion/Dream1/SpaceAgeManager.cs
+++ b/Assets/Scripts/Expansion/Dream1/SpaceAgeManager.cs
@@ -145,8 +145,8 @@ public class SpaceAgeManager : MonoBehaviour
             if (sd1.spaceFactories >= 1) _factoriesTime += Time.deltaTime * (float)multi;
 
             factoriesFillBar.fillAmount =
-                (float)StaticMethods.FillBar(sd1.cities, _factoriesDuration, multi, _factoriesTime);
-            factoriesFillText.text = StaticMethods.TimerText(sd1.cities, _factoriesDuration, multi, _factoriesTime);
+                (float)StaticMethods.FillBar(sd1.spaceFactories, _factoriesDuration, multi, _factoriesTime);
+            factoriesFillText.text = StaticMethods.TimerText(sd1.spaceFactories, _factoriesDuration, multi, _factoriesTime);
 
             while (_factoriesTime >= _factoriesDuration)
             {
@@ -162,7 +162,7 @@ public class SpaceAgeManager : MonoBehaviour
             factoriesInventoryFillBar.fillAmount = 1;
             factoriesInventoryBarText.text = $"{sd1.dysonPanels}/1000";
             factoriesFillBar.fillAmount = 1;
-            factoriesFillText.text = StaticMethods.TimerText(sd1.cities, _factoriesDuration, multi, _factoriesTime);
+            factoriesFillText.text = StaticMethods.TimerText(sd1.spaceFactories, _factoriesDuration, multi, _factoriesTime);
         }
     }
 
@@ -185,10 +185,10 @@ public class SpaceAgeManager : MonoBehaviour
             }
         }
 
-        if (sd1.railgunCharge >= sd1.railgunMaxCharge && sd1.dysonPanels >=
-            (oracle.saveSettings.sdPrestige.doubleTimeRate >= 1 && sdp.doDoubleTime
-                ? 10 * oracle.saveSettings.sdPrestige.doubleTimeRate
-                : 10) && !_firing)
+        int panelsRequired = GetDysonPanelsRequiredToFire();
+        if (sd1.railgunCharge >= sd1.railgunMaxCharge &&
+            sd1.dysonPanels >= panelsRequired &&
+            !_firing)
         {
             _firing = true;
             _fireTime = 0;
@@ -228,6 +228,14 @@ public class SpaceAgeManager : MonoBehaviour
         if (sd1.railgunCharge < sd1.railgunMaxCharge / 10f || _fireTimes <= 0) _firing = false;
 
         railgunsFillBar.fillAmount = fill;
+    }
+
+    private int GetDysonPanelsRequiredToFire()
+    {
+        const int basePanelsRequired = 10;
+        if (!sdp.doDoubleTime || sdp.doubleTimeRate < 1)
+            return basePanelsRequired;
+        return basePanelsRequired * (int)sdp.doubleTimeRate;
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Phase 0 bug fixes from the [Quantum/Reality Refactor Plan](Documentation/QuantumAndRealityRefactorPlan.md):

- **Fixed Space Factory fill bar bug** - Progress bar was checking `sd1.cities` instead of `sd1.spaceFactories`, causing incorrect progress display
- **Clarified railgun firing condition** - Extracted confusing nested ternary to `GetDysonPanelsRequiredToFire()` method

## Testing Checklist

- [x] Code compiles without errors
- [x] No save compatibility impact (behavior unchanged, just bug fix)
- [x] Fill bar now correctly shows Space Factory production progress
- [x] Railgun firing logic unchanged, just more readable

## Changes

| File | Change |
|------|--------|
| SpaceAgeManager.cs | Fixed `sd1.cities` → `sd1.spaceFactories` on lines 148-149, 165 |
| SpaceAgeManager.cs | Added `GetDysonPanelsRequiredToFire()` helper method |

🤖 Generated with [Claude Code](https://claude.ai/code)