### PR TITLE
feat: Add Quantum, Worker, and Avocado services (Phase 2)

### DIFF
--- a/Assets/Scripts/Services/AvocadoService.cs
+++ b/Assets/Scripts/Services/AvocadoService.cs
@@ -1,0 +1,150 @@
+using System;
+using Expansion;
+using static Expansion.Oracle;
+using static IdleDysonSwarm.Systems.Constants.RealityConstants;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Default implementation of IAvocadoService that wraps Oracle static access.
+    /// Manages the Avocado cross-system aggregator that produces a global production multiplier.
+    /// </summary>
+    public sealed class AvocadoService : IAvocadoService
+    {
+        private PrestigePlus PrestigePlus => StaticSaveSettings.prestigePlus;
+
+        #region State Properties
+
+        public bool IsUnlocked => PrestigePlus.avocatoPurchased;
+        public double AccumulatedIP => PrestigePlus.avocatoIP;
+        public double AccumulatedInfluence => PrestigePlus.avocatoInfluence;
+        public double AccumulatedStrangeMatter => PrestigePlus.avocatoStrangeMatter;
+        public double OverflowMultiplier => PrestigePlus.avocatoOverflow;
+
+        #endregion
+
+        #region Calculations
+
+        public double GlobalBuff
+        {
+            get
+            {
+                if (!IsUnlocked)
+                    return 1.0;
+
+                double multi = 1.0;
+
+                if (HasMinimumIP)
+                    multi *= Math.Log10(AccumulatedIP);
+
+                if (HasMinimumInfluence)
+                    multi *= Math.Log10(AccumulatedInfluence);
+
+                if (HasMinimumStrangeMatter)
+                    multi *= Math.Log10(AccumulatedStrangeMatter);
+
+                if (OverflowMultiplier >= 1)
+                    multi *= 1 + OverflowMultiplier;
+
+                return multi;
+            }
+        }
+
+        public bool HasMinimumIP => AccumulatedIP >= AvocadoLogThreshold;
+        public bool HasMinimumInfluence => AccumulatedInfluence >= AvocadoLogThreshold;
+        public bool HasMinimumStrangeMatter => AccumulatedStrangeMatter >= AvocadoLogThreshold;
+
+        public double IPContribution =>
+            HasMinimumIP ? Math.Log10(AccumulatedIP) : 0;
+
+        public double InfluenceContribution =>
+            HasMinimumInfluence ? Math.Log10(AccumulatedInfluence) : 0;
+
+        public double StrangeMatterContribution =>
+            HasMinimumStrangeMatter ? Math.Log10(AccumulatedStrangeMatter) : 0;
+
+        public double OverflowContribution =>
+            OverflowMultiplier >= 1 ? 1 + OverflowMultiplier : 1;
+
+        #endregion
+
+        #region Actions
+
+        public void FeedIP(double amount)
+        {
+            if (amount <= 0 || !IsUnlocked)
+                return;
+
+            double previousBuff = GlobalBuff;
+            PrestigePlus.avocatoIP += amount;
+
+            OnFed?.Invoke();
+
+            double newBuff = GlobalBuff;
+            if (Math.Abs(newBuff - previousBuff) > 0.001)
+            {
+                OnGlobalBuffChanged?.Invoke(newBuff);
+            }
+        }
+
+        public void FeedInfluence(long amount)
+        {
+            if (amount <= 0 || !IsUnlocked)
+                return;
+
+            double previousBuff = GlobalBuff;
+            PrestigePlus.avocatoInfluence += amount;
+
+            OnFed?.Invoke();
+
+            double newBuff = GlobalBuff;
+            if (Math.Abs(newBuff - previousBuff) > 0.001)
+            {
+                OnGlobalBuffChanged?.Invoke(newBuff);
+            }
+        }
+
+        public void FeedStrangeMatter(double amount)
+        {
+            if (amount <= 0 || !IsUnlocked)
+                return;
+
+            double previousBuff = GlobalBuff;
+            PrestigePlus.avocatoStrangeMatter += amount;
+
+            OnFed?.Invoke();
+
+            double newBuff = GlobalBuff;
+            if (Math.Abs(newBuff - previousBuff) > 0.001)
+            {
+                OnGlobalBuffChanged?.Invoke(newBuff);
+            }
+        }
+
+        public void AddOverflow(double amount)
+        {
+            if (amount <= 0 || !IsUnlocked)
+                return;
+
+            double previousBuff = GlobalBuff;
+            PrestigePlus.avocatoOverflow += amount;
+
+            OnFed?.Invoke();
+
+            double newBuff = GlobalBuff;
+            if (Math.Abs(newBuff - previousBuff) > 0.001)
+            {
+                OnGlobalBuffChanged?.Invoke(newBuff);
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        public event Action<double> OnGlobalBuffChanged;
+        public event Action OnFed;
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/AvocadoService.cs.meta
+++ b/Assets/Scripts/Services/AvocadoService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e6919457c6d78d04c890575416b0b53e

--- a/Assets/Scripts/Services/IAvocadoService.cs
+++ b/Assets/Scripts/Services/IAvocadoService.cs
@@ -1,0 +1,135 @@
+using System;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Service interface for the Avocado cross-system aggregator.
+    /// Avocado consumes resources from Infinity, Reality, and Dream1 systems
+    /// to produce a global production multiplier.
+    /// </summary>
+    /// <remarks>
+    /// Avocado is unlocked by spending 42 Quantum Points.
+    /// The global buff is calculated as:
+    /// Log10(IP) × Log10(Influence) × Log10(StrangeMatter) × (1 + Overflow)
+    /// Each component only contributes if its value is >= 10 (AvocadoLogThreshold).
+    /// </remarks>
+    public interface IAvocadoService
+    {
+        #region State Properties
+
+        /// <summary>
+        /// Whether the Avocado system is unlocked.
+        /// Unlocked by purchasing the Avocado upgrade with 42 Quantum Points.
+        /// </summary>
+        bool IsUnlocked { get; }
+
+        /// <summary>
+        /// Total Infinity Points accumulated in the Avocado.
+        /// </summary>
+        double AccumulatedIP { get; }
+
+        /// <summary>
+        /// Total Influence accumulated in the Avocado.
+        /// </summary>
+        double AccumulatedInfluence { get; }
+
+        /// <summary>
+        /// Total Strange Matter accumulated in the Avocado.
+        /// </summary>
+        double AccumulatedStrangeMatter { get; }
+
+        /// <summary>
+        /// Overflow multiplier bonus.
+        /// </summary>
+        double OverflowMultiplier { get; }
+
+        #endregion
+
+        #region Calculations
+
+        /// <summary>
+        /// Gets the current global buff multiplier.
+        /// Returns 1 if Avocado is not unlocked or no resources meet minimum threshold.
+        /// </summary>
+        double GlobalBuff { get; }
+
+        /// <summary>
+        /// Whether IP meets the minimum threshold (>= 10) to contribute to multiplier.
+        /// </summary>
+        bool HasMinimumIP { get; }
+
+        /// <summary>
+        /// Whether Influence meets the minimum threshold (>= 10) to contribute to multiplier.
+        /// </summary>
+        bool HasMinimumInfluence { get; }
+
+        /// <summary>
+        /// Whether Strange Matter meets the minimum threshold (>= 10) to contribute to multiplier.
+        /// </summary>
+        bool HasMinimumStrangeMatter { get; }
+
+        /// <summary>
+        /// Gets the Log10 contribution from IP (0 if below threshold).
+        /// </summary>
+        double IPContribution { get; }
+
+        /// <summary>
+        /// Gets the Log10 contribution from Influence (0 if below threshold).
+        /// </summary>
+        double InfluenceContribution { get; }
+
+        /// <summary>
+        /// Gets the Log10 contribution from Strange Matter (0 if below threshold).
+        /// </summary>
+        double StrangeMatterContribution { get; }
+
+        /// <summary>
+        /// Gets the overflow contribution (1 + OverflowMultiplier if >= 1, otherwise 1).
+        /// </summary>
+        double OverflowContribution { get; }
+
+        #endregion
+
+        #region Actions
+
+        /// <summary>
+        /// Feeds Infinity Points into the Avocado.
+        /// </summary>
+        /// <param name="amount">Amount of IP to feed.</param>
+        void FeedIP(double amount);
+
+        /// <summary>
+        /// Feeds Influence into the Avocado.
+        /// </summary>
+        /// <param name="amount">Amount of Influence to feed.</param>
+        void FeedInfluence(long amount);
+
+        /// <summary>
+        /// Feeds Strange Matter into the Avocado.
+        /// </summary>
+        /// <param name="amount">Amount of Strange Matter to feed.</param>
+        void FeedStrangeMatter(double amount);
+
+        /// <summary>
+        /// Adds to the overflow multiplier.
+        /// </summary>
+        /// <param name="amount">Amount to add to overflow.</param>
+        void AddOverflow(double amount);
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Fired when the global buff value changes.
+        /// </summary>
+        event Action<double> OnGlobalBuffChanged;
+
+        /// <summary>
+        /// Fired when resources are fed into the Avocado.
+        /// </summary>
+        event Action OnFed;
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/IAvocadoService.cs.meta
+++ b/Assets/Scripts/Services/IAvocadoService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 862f81bf933cc614194df40e853b18e7

--- a/Assets/Scripts/Services/IQuantumService.cs
+++ b/Assets/Scripts/Services/IQuantumService.cs
@@ -1,0 +1,221 @@
+using System;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Defines upgrade types available in the Quantum Leap system.
+    /// </summary>
+    public enum QuantumUpgradeType
+    {
+        BotMultitasking,
+        DoubleIP,
+        BreakTheLoop,
+        QuantumEntanglement,
+        Automation,
+        Secrets,
+        Division,
+        Avocado,
+        Fragments,
+        Purity,
+        Terra,
+        Power,
+        Paragade,
+        Stellar,
+        InfluenceSpeed,
+        CashBonus,
+        ScienceBonus
+    }
+
+    /// <summary>
+    /// Service interface for the Quantum Leap system.
+    /// Manages Quantum Points, upgrade purchases, and quantum leap operations.
+    /// </summary>
+    /// <remarks>
+    /// The Quantum Leap system converts 42 Infinity Points into 1 Quantum Point.
+    /// Quantum Points are spent on upgrades affecting Infinity mechanics.
+    /// </remarks>
+    public interface IQuantumService
+    {
+        #region State Properties
+
+        /// <summary>
+        /// Total Quantum Points ever earned.
+        /// </summary>
+        long TotalPoints { get; }
+
+        /// <summary>
+        /// Quantum Points available to spend (Total - Spent).
+        /// </summary>
+        long AvailablePoints { get; }
+
+        /// <summary>
+        /// Quantum Points spent on upgrades.
+        /// </summary>
+        long SpentPoints { get; }
+
+        /// <summary>
+        /// Current Influence Speed bonus (already scaled).
+        /// This is the raw bonus added to base worker generation speed.
+        /// Each purchase adds +4 (InfluenceSpeedPerLevel) to this value.
+        /// </summary>
+        long InfluenceSpeedLevel { get; }
+
+        /// <summary>
+        /// Current Cash Bonus upgrade level.
+        /// Each level adds +5% cash multiplier.
+        /// </summary>
+        long CashBonusLevel { get; }
+
+        /// <summary>
+        /// Current Science Bonus upgrade level.
+        /// Each level adds +5% science multiplier.
+        /// </summary>
+        long ScienceBonusLevel { get; }
+
+        /// <summary>
+        /// Permanent secrets purchased (0-27, adds +3 per purchase).
+        /// </summary>
+        long PermanentSecrets { get; }
+
+        /// <summary>
+        /// Number of Division upgrades purchased.
+        /// Each provides 10x multiplier; cost scales exponentially (2^n * 2).
+        /// </summary>
+        long DivisionsPurchased { get; }
+
+        #endregion
+
+        #region Unlock State
+
+        /// <summary>
+        /// Whether Bot Multitasking is unlocked.
+        /// </summary>
+        bool IsBotMultitaskingUnlocked { get; }
+
+        /// <summary>
+        /// Whether Double IP is unlocked.
+        /// </summary>
+        bool IsDoubleIPUnlocked { get; }
+
+        /// <summary>
+        /// Whether Break The Loop (DysonVerse upgrade) is unlocked.
+        /// </summary>
+        bool IsBreakTheLoopUnlocked { get; }
+
+        /// <summary>
+        /// Whether Quantum Entanglement (auto-prestige at 42 IP) is unlocked.
+        /// </summary>
+        bool IsQuantumEntanglementUnlocked { get; }
+
+        /// <summary>
+        /// Whether Automation is unlocked.
+        /// </summary>
+        bool IsAutomationUnlocked { get; }
+
+        /// <summary>
+        /// Whether Avocado system is unlocked.
+        /// </summary>
+        bool IsAvocadoUnlocked { get; }
+
+        /// <summary>
+        /// Whether Fragments upgrade is unlocked.
+        /// </summary>
+        bool IsFragmentsUnlocked { get; }
+
+        /// <summary>
+        /// Whether Purity upgrade is unlocked.
+        /// </summary>
+        bool IsPurityUnlocked { get; }
+
+        /// <summary>
+        /// Whether Terra upgrade is unlocked.
+        /// </summary>
+        bool IsTerraUnlocked { get; }
+
+        /// <summary>
+        /// Whether Power upgrade is unlocked.
+        /// </summary>
+        bool IsPowerUnlocked { get; }
+
+        /// <summary>
+        /// Whether Paragade upgrade is unlocked.
+        /// </summary>
+        bool IsParagadeUnlocked { get; }
+
+        /// <summary>
+        /// Whether Stellar upgrade is unlocked.
+        /// </summary>
+        bool IsStellarUnlocked { get; }
+
+        #endregion
+
+        #region Calculations
+
+        /// <summary>
+        /// Gets the cost in Quantum Points for a specific upgrade.
+        /// </summary>
+        /// <param name="upgrade">The upgrade type to check.</param>
+        /// <returns>The cost in Quantum Points.</returns>
+        int GetUpgradeCost(QuantumUpgradeType upgrade);
+
+        /// <summary>
+        /// Checks if the player can afford a specific upgrade.
+        /// </summary>
+        /// <param name="upgrade">The upgrade type to check.</param>
+        /// <returns>True if affordable, false otherwise.</returns>
+        bool CanAfford(QuantumUpgradeType upgrade);
+
+        /// <summary>
+        /// Checks if an upgrade is already purchased (for one-time unlocks).
+        /// </summary>
+        /// <param name="upgrade">The upgrade type to check.</param>
+        /// <returns>True if already purchased.</returns>
+        bool IsUpgradePurchased(QuantumUpgradeType upgrade);
+
+        /// <summary>
+        /// Gets the calculated worker generation speed.
+        /// Formula: BaseWorkerGenerationSpeed + InfluenceSpeedLevel
+        /// </summary>
+        int CalculatedWorkerSpeed { get; }
+
+        /// <summary>
+        /// Gets the current cash bonus multiplier based on CashBonusLevel.
+        /// Formula: 1 + (CashBonusLevel * CashBonusPerPoint)
+        /// </summary>
+        double CashMultiplier { get; }
+
+        /// <summary>
+        /// Gets the current science bonus multiplier based on ScienceBonusLevel.
+        /// Formula: 1 + (ScienceBonusLevel * ScienceBonusPerPoint)
+        /// </summary>
+        double ScienceMultiplier { get; }
+
+        #endregion
+
+        #region Actions
+
+        /// <summary>
+        /// Attempts to purchase an upgrade.
+        /// </summary>
+        /// <param name="upgrade">The upgrade to purchase.</param>
+        /// <returns>True if purchase succeeded, false otherwise.</returns>
+        bool TryPurchaseUpgrade(QuantumUpgradeType upgrade);
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Fired when an upgrade is successfully purchased.
+        /// </summary>
+        event Action<QuantumUpgradeType> OnUpgradePurchased;
+
+        /// <summary>
+        /// Fired when Quantum Points are earned (after a Quantum Leap).
+        /// Parameter is the number of points earned.
+        /// </summary>
+        event Action<long> OnQuantumPointsEarned;
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/IQuantumService.cs.meta
+++ b/Assets/Scripts/Services/IQuantumService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bab08d35375fd742b21ac2fabc53297

--- a/Assets/Scripts/Services/IWorkerService.cs
+++ b/Assets/Scripts/Services/IWorkerService.cs
@@ -1,0 +1,119 @@
+using System;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Service interface for the Worker/Influence system.
+    /// Manages worker generation, influence gathering, and offline progress.
+    /// </summary>
+    /// <remarks>
+    /// Workers accumulate over time (speed based on Quantum upgrades).
+    /// When 128 workers are ready, they can be gathered to convert to Influence currency.
+    /// Influence feeds into Dream1 economy and Avocado system.
+    /// </remarks>
+    public interface IWorkerService
+    {
+        #region State Properties
+
+        /// <summary>
+        /// Current number of workers ready to gather (0-128).
+        /// </summary>
+        long WorkersReady { get; }
+
+        /// <summary>
+        /// Current Influence currency balance.
+        /// </summary>
+        long InfluenceBalance { get; }
+
+        /// <summary>
+        /// Total worker batches processed (Universe Designation counter).
+        /// </summary>
+        long WorkerBatchesProcessed { get; }
+
+        /// <summary>
+        /// Whether auto-gather is enabled.
+        /// When true, workers are automatically gathered when batch is full.
+        /// </summary>
+        bool AutoGatherEnabled { get; set; }
+
+        #endregion
+
+        #region Calculations
+
+        /// <summary>
+        /// Current worker generation speed (workers per second).
+        /// Formula: BaseWorkerGenerationSpeed + (InfluenceSpeedLevel * InfluenceSpeedPerLevel)
+        /// </summary>
+        float WorkerGenerationSpeed { get; }
+
+        /// <summary>
+        /// Worker fill percentage (0-1).
+        /// Used for UI fill bars.
+        /// </summary>
+        float WorkerFillPercent { get; }
+
+        /// <summary>
+        /// Whether a full batch of workers is ready to gather.
+        /// </summary>
+        bool CanGather { get; }
+
+        /// <summary>
+        /// Whether the Reality system is unlocked.
+        /// Unlocked when player has Quantum Points or has 27 secrets.
+        /// </summary>
+        bool IsRealityUnlocked { get; }
+
+        #endregion
+
+        #region Actions
+
+        /// <summary>
+        /// Attempts to gather the current batch of workers into influence.
+        /// Only succeeds if WorkersReady >= WorkerBatchSize.
+        /// </summary>
+        /// <returns>True if gather succeeded, false otherwise.</returns>
+        bool TryGatherInfluence();
+
+        /// <summary>
+        /// Applies offline progress for accumulated time.
+        /// </summary>
+        /// <param name="seconds">Number of offline seconds to process.</param>
+        void ApplyOfflineProgress(double seconds);
+
+        /// <summary>
+        /// Spends influence currency.
+        /// </summary>
+        /// <param name="amount">Amount to spend.</param>
+        /// <returns>True if spend succeeded (had enough), false otherwise.</returns>
+        bool TrySpendInfluence(long amount);
+
+        /// <summary>
+        /// Adds influence currency directly (used by systems like Dream1).
+        /// </summary>
+        /// <param name="amount">Amount to add.</param>
+        void AddInfluence(long amount);
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Fired when influence is gathered from workers.
+        /// Parameter is the amount gathered.
+        /// </summary>
+        event Action<long> OnInfluenceGathered;
+
+        /// <summary>
+        /// Fired when influence is spent.
+        /// Parameter is the amount spent.
+        /// </summary>
+        event Action<long> OnInfluenceSpent;
+
+        /// <summary>
+        /// Fired when a worker batch is completed.
+        /// </summary>
+        event Action OnWorkerBatchCompleted;
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/IWorkerService.cs.meta
+++ b/Assets/Scripts/Services/IWorkerService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19d28f2589a3d8d48a25a83fa1dfdf0f

--- a/Assets/Scripts/Services/QuantumService.cs
+++ b/Assets/Scripts/Services/QuantumService.cs
@@ -1,0 +1,261 @@
+using System;
+using Expansion;
+using static Expansion.Oracle;
+using static IdleDysonSwarm.Systems.Constants.QuantumConstants;
+using static IdleDysonSwarm.Systems.Constants.RealityConstants;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Default implementation of IQuantumService that wraps Oracle static access.
+    /// Manages Quantum Points, upgrade purchases, and quantum leap operations.
+    /// </summary>
+    public sealed class QuantumService : IQuantumService
+    {
+        private PrestigePlus PrestigePlus => StaticSaveSettings.prestigePlus;
+        private DysonVersePrestigeData PrestigeData => StaticPrestigeData;
+
+        #region State Properties
+
+        public long TotalPoints => PrestigePlus.points;
+        public long AvailablePoints => PrestigePlus.points - PrestigePlus.spentPoints;
+        public long SpentPoints => PrestigePlus.spentPoints;
+        public long InfluenceSpeedLevel => PrestigePlus.influence;
+        public long CashBonusLevel => PrestigePlus.cash;
+        public long ScienceBonusLevel => PrestigePlus.science;
+        public long PermanentSecrets => PrestigePlus.secrets;
+        public long DivisionsPurchased => PrestigePlus.divisionsPurchased;
+
+        #endregion
+
+        #region Unlock State
+
+        public bool IsBotMultitaskingUnlocked => PrestigePlus.botMultitasking;
+        public bool IsDoubleIPUnlocked => PrestigePlus.doubleIP;
+        public bool IsBreakTheLoopUnlocked => PrestigePlus.breakTheLoop;
+        public bool IsQuantumEntanglementUnlocked => PrestigePlus.quantumEntanglement;
+        public bool IsAutomationUnlocked => PrestigePlus.automation;
+        public bool IsAvocadoUnlocked => PrestigePlus.avocatoPurchased;
+        public bool IsFragmentsUnlocked => PrestigePlus.fragments;
+        public bool IsPurityUnlocked => PrestigePlus.purity;
+        public bool IsTerraUnlocked => PrestigePlus.terra;
+        public bool IsPowerUnlocked => PrestigePlus.power;
+        public bool IsParagadeUnlocked => PrestigePlus.paragade;
+        public bool IsStellarUnlocked => PrestigePlus.stellar;
+
+        #endregion
+
+        #region Calculations
+
+        public int GetUpgradeCost(QuantumUpgradeType upgrade)
+        {
+            return upgrade switch
+            {
+                QuantumUpgradeType.BotMultitasking => BasicUpgradeCost,
+                QuantumUpgradeType.DoubleIP => BasicUpgradeCost,
+                QuantumUpgradeType.BreakTheLoop => BreakTheLoopCost,
+                QuantumUpgradeType.QuantumEntanglement => QuantumEntanglementCost,
+                QuantumUpgradeType.Automation => BasicUpgradeCost,
+                QuantumUpgradeType.Secrets => BasicUpgradeCost,
+                QuantumUpgradeType.Division => CalculateDivisionCost(),
+                QuantumUpgradeType.Avocado => AvocadoCost,
+                QuantumUpgradeType.Fragments => FragmentCost,
+                QuantumUpgradeType.Purity => PurityCost,
+                QuantumUpgradeType.Terra => TerraCost,
+                QuantumUpgradeType.Power => PowerCost,
+                QuantumUpgradeType.Paragade => ParagadeCost,
+                QuantumUpgradeType.Stellar => StellarCost,
+                QuantumUpgradeType.InfluenceSpeed => BasicUpgradeCost,
+                QuantumUpgradeType.CashBonus => BasicUpgradeCost,
+                QuantumUpgradeType.ScienceBonus => BasicUpgradeCost,
+                _ => int.MaxValue
+            };
+        }
+
+        /// <summary>
+        /// Division cost scales exponentially: 2^n * 2
+        /// </summary>
+        private int CalculateDivisionCost()
+        {
+            if (DivisionsPurchased >= 1)
+            {
+                return (int)Math.Pow(2, DivisionsPurchased) * 2;
+            }
+            return 2;
+        }
+
+        public bool CanAfford(QuantumUpgradeType upgrade)
+        {
+            return AvailablePoints >= GetUpgradeCost(upgrade);
+        }
+
+        public bool IsUpgradePurchased(QuantumUpgradeType upgrade)
+        {
+            return upgrade switch
+            {
+                QuantumUpgradeType.BotMultitasking => IsBotMultitaskingUnlocked,
+                QuantumUpgradeType.DoubleIP => IsDoubleIPUnlocked,
+                QuantumUpgradeType.BreakTheLoop => IsBreakTheLoopUnlocked,
+                QuantumUpgradeType.QuantumEntanglement => IsQuantumEntanglementUnlocked,
+                QuantumUpgradeType.Automation => IsAutomationUnlocked,
+                QuantumUpgradeType.Secrets => PermanentSecrets >= MaxSecrets,
+                QuantumUpgradeType.Division => DivisionsPurchased >= 19, // Max divisions
+                QuantumUpgradeType.Avocado => IsAvocadoUnlocked,
+                QuantumUpgradeType.Fragments => IsFragmentsUnlocked,
+                QuantumUpgradeType.Purity => IsPurityUnlocked,
+                QuantumUpgradeType.Terra => IsTerraUnlocked,
+                QuantumUpgradeType.Power => IsPowerUnlocked,
+                QuantumUpgradeType.Paragade => IsParagadeUnlocked,
+                QuantumUpgradeType.Stellar => IsStellarUnlocked,
+                // Repeatable upgrades are never "purchased" (always available)
+                QuantumUpgradeType.InfluenceSpeed => false,
+                QuantumUpgradeType.CashBonus => false,
+                QuantumUpgradeType.ScienceBonus => false,
+                _ => false
+            };
+        }
+
+        public int CalculatedWorkerSpeed => BaseWorkerGenerationSpeed + (int)InfluenceSpeedLevel;
+
+        public double CashMultiplier => 1 + (CashBonusLevel * CashBonusPerPoint);
+
+        public double ScienceMultiplier => 1 + (ScienceBonusLevel * ScienceBonusPerPoint);
+
+        #endregion
+
+        #region Actions
+
+        public bool TryPurchaseUpgrade(QuantumUpgradeType upgrade)
+        {
+            // Check if already purchased (for one-time unlocks)
+            if (IsUpgradePurchased(upgrade))
+                return false;
+
+            // Check affordability
+            if (!CanAfford(upgrade))
+                return false;
+
+            int cost = GetUpgradeCost(upgrade);
+
+            // Apply upgrade
+            bool success = ApplyUpgrade(upgrade);
+            if (!success)
+                return false;
+
+            // Spend points
+            PrestigePlus.spentPoints += cost;
+
+            // Fire event
+            OnUpgradePurchased?.Invoke(upgrade);
+
+            return true;
+        }
+
+        private bool ApplyUpgrade(QuantumUpgradeType upgrade)
+        {
+            switch (upgrade)
+            {
+                case QuantumUpgradeType.BotMultitasking:
+                    PrestigePlus.botMultitasking = true;
+                    return true;
+
+                case QuantumUpgradeType.DoubleIP:
+                    PrestigePlus.doubleIP = true;
+                    return true;
+
+                case QuantumUpgradeType.BreakTheLoop:
+                    PrestigePlus.breakTheLoop = true;
+                    return true;
+
+                case QuantumUpgradeType.QuantumEntanglement:
+                    PrestigePlus.quantumEntanglement = true;
+                    return true;
+
+                case QuantumUpgradeType.Automation:
+                    PrestigePlus.automation = true;
+                    // Also sets automation flags on PrestigeData
+                    PrestigeData.infinityAutoBots = true;
+                    PrestigeData.infinityAutoResearch = true;
+                    return true;
+
+                case QuantumUpgradeType.Secrets:
+                    if (PermanentSecrets >= MaxSecrets)
+                        return false;
+                    // Add 3 secrets to both permanent and session storage (capped at 27)
+                    PrestigePlus.secrets += SecretsPerPurchase;
+                    if (PrestigePlus.secrets > MaxSecrets)
+                        PrestigePlus.secrets = MaxSecrets;
+                    PrestigeData.secretsOfTheUniverse += SecretsPerPurchase;
+                    if (PrestigeData.secretsOfTheUniverse > MaxSecrets)
+                        PrestigeData.secretsOfTheUniverse = MaxSecrets;
+                    return true;
+
+                case QuantumUpgradeType.Division:
+                    if (DivisionsPurchased >= 19)
+                        return false;
+                    PrestigePlus.divisionsPurchased++;
+                    return true;
+
+                case QuantumUpgradeType.Avocado:
+                    PrestigePlus.avocatoPurchased = true;
+                    return true;
+
+                case QuantumUpgradeType.Fragments:
+                    PrestigePlus.fragments = true;
+                    return true;
+
+                case QuantumUpgradeType.Purity:
+                    PrestigePlus.purity = true;
+                    return true;
+
+                case QuantumUpgradeType.Terra:
+                    PrestigePlus.terra = true;
+                    return true;
+
+                case QuantumUpgradeType.Power:
+                    PrestigePlus.power = true;
+                    return true;
+
+                case QuantumUpgradeType.Paragade:
+                    PrestigePlus.paragade = true;
+                    return true;
+
+                case QuantumUpgradeType.Stellar:
+                    PrestigePlus.stellar = true;
+                    return true;
+
+                case QuantumUpgradeType.InfluenceSpeed:
+                    PrestigePlus.influence += InfluenceSpeedPerLevel;
+                    return true;
+
+                case QuantumUpgradeType.CashBonus:
+                    PrestigePlus.cash++;
+                    return true;
+
+                case QuantumUpgradeType.ScienceBonus:
+                    PrestigePlus.science++;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        public event Action<QuantumUpgradeType> OnUpgradePurchased;
+        public event Action<long> OnQuantumPointsEarned;
+
+        /// <summary>
+        /// Called externally when quantum points are earned (e.g., after a Quantum Leap).
+        /// </summary>
+        internal void NotifyQuantumPointsEarned(long amount)
+        {
+            OnQuantumPointsEarned?.Invoke(amount);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/QuantumService.cs.meta
+++ b/Assets/Scripts/Services/QuantumService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7807e3c5c6d314d4f97830cb5885185d

--- a/Assets/Scripts/Services/ServiceProvider.cs
+++ b/Assets/Scripts/Services/ServiceProvider.cs
@@ -56,6 +56,19 @@ namespace IdleDysonSwarm.Services
             ServiceLocator.Register<IFacilityService>(facilityService);
             Debug.Log("  ✓ IFacilityService registered");
 
+            // Register Quantum/Reality system services
+            var quantumService = new QuantumService();
+            ServiceLocator.Register<IQuantumService>(quantumService);
+            Debug.Log("  ✓ IQuantumService registered");
+
+            var workerService = new WorkerService();
+            ServiceLocator.Register<IWorkerService>(workerService);
+            Debug.Log("  ✓ IWorkerService registered");
+
+            var avocadoService = new AvocadoService();
+            ServiceLocator.Register<IAvocadoService>(avocadoService);
+            Debug.Log("  ✓ IAvocadoService registered");
+
             Debug.Log("[ServiceProvider] All services registered successfully!");
         }
 
@@ -69,6 +82,9 @@ namespace IdleDysonSwarm.Services
             allRegistered &= CheckService<IGameStateService>();
             allRegistered &= CheckService<IGameDataService>();
             allRegistered &= CheckService<IFacilityService>();
+            allRegistered &= CheckService<IQuantumService>();
+            allRegistered &= CheckService<IWorkerService>();
+            allRegistered &= CheckService<IAvocadoService>();
 
             if (allRegistered)
             {

--- a/Assets/Scripts/Services/WorkerService.cs
+++ b/Assets/Scripts/Services/WorkerService.cs
@@ -1,0 +1,132 @@
+using System;
+using Expansion;
+using static Expansion.Oracle;
+using static IdleDysonSwarm.Systems.Constants.RealityConstants;
+using static IdleDysonSwarm.Systems.Constants.QuantumConstants;
+
+namespace IdleDysonSwarm.Services
+{
+    /// <summary>
+    /// Default implementation of IWorkerService that wraps Oracle static access.
+    /// Manages worker generation, influence gathering, and offline progress.
+    /// </summary>
+    public sealed class WorkerService : IWorkerService
+    {
+        private SaveData SaveData => StaticSaveSettings.saveData;
+        private PrestigePlus PrestigePlus => StaticSaveSettings.prestigePlus;
+        private DysonVersePrestigeData PrestigeData => StaticPrestigeData;
+
+        #region State Properties
+
+        public long WorkersReady => SaveData.workersReadyToGo;
+        public long InfluenceBalance => SaveData.influence;
+        public long WorkerBatchesProcessed => SaveData.universesConsumed;
+
+        public bool AutoGatherEnabled
+        {
+            get => SaveData.workerAutoConvert;
+            set => SaveData.workerAutoConvert = value;
+        }
+
+        #endregion
+
+        #region Calculations
+
+        public float WorkerGenerationSpeed =>
+            BaseWorkerGenerationSpeed + PrestigePlus.influence;
+
+        public float WorkerFillPercent => (float)WorkersReady / WorkerBatchSize;
+
+        public bool CanGather => WorkersReady >= WorkerBatchSize;
+
+        public bool IsRealityUnlocked =>
+            PrestigePlus.points >= 1 ||
+            PrestigeData.secretsOfTheUniverse >= MaxSecrets;
+
+        #endregion
+
+        #region Actions
+
+        public bool TryGatherInfluence()
+        {
+            if (!CanGather)
+                return false;
+
+            SaveData.influence += WorkerBatchSize;
+            SaveData.workersReadyToGo = 0;
+
+            OnInfluenceGathered?.Invoke(WorkerBatchSize);
+
+            return true;
+        }
+
+        public void ApplyOfflineProgress(double seconds)
+        {
+            int amountWhileAway = (int)Math.Round(seconds * WorkerGenerationSpeed);
+
+            if (AutoGatherEnabled)
+            {
+                // Auto-convert: add directly to influence
+                SaveData.influence += amountWhileAway;
+                SaveData.universesConsumed += amountWhileAway;
+            }
+            else
+            {
+                // Manual mode: accumulate workers up to batch size
+                long total = SaveData.workersReadyToGo + amountWhileAway;
+                if (total >= WorkerBatchSize)
+                {
+                    // Calculate overflow before clamping (fixes minor bug in original)
+                    long overflow = SaveData.workersReadyToGo;
+                    SaveData.workersReadyToGo = WorkerBatchSize;
+                    SaveData.universesConsumed += WorkerBatchSize - overflow;
+                }
+                else
+                {
+                    SaveData.workersReadyToGo += amountWhileAway;
+                    SaveData.universesConsumed += amountWhileAway;
+                }
+            }
+        }
+
+        public bool TrySpendInfluence(long amount)
+        {
+            if (amount <= 0)
+                return false;
+
+            if (SaveData.influence < amount)
+                return false;
+
+            SaveData.influence -= amount;
+            OnInfluenceSpent?.Invoke(amount);
+
+            return true;
+        }
+
+        public void AddInfluence(long amount)
+        {
+            if (amount > 0)
+            {
+                SaveData.influence += amount;
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        public event Action<long> OnInfluenceGathered;
+        public event Action<long> OnInfluenceSpent;
+        public event Action OnWorkerBatchCompleted;
+
+        /// <summary>
+        /// Called externally when a worker batch is completed (e.g., by InceptionController).
+        /// </summary>
+        internal void NotifyWorkerBatchCompleted()
+        {
+            OnWorkerBatchCompleted?.Invoke();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Services/WorkerService.cs.meta
+++ b/Assets/Scripts/Services/WorkerService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 20be2ace29c8b0e4f916a03ab244e65d


### PR DESCRIPTION
## Summary

Phase 2 of the Quantum Leap & Reality Systems Refactor: Create service interfaces and implementations.

- **IQuantumService/QuantumService**: Manages Quantum Points, upgrade purchases (one-time unlocks and repeatable), cost calculations, and multipliers (Cash/Science bonuses)
- **IWorkerService/WorkerService**: Handles worker generation, influence gathering, offline progress, and influence spending
- **IAvocadoService/AvocadoService**: Cross-system aggregator consuming IP/Influence/Strange Matter, producing Log10-based global production buff

### New Files

| File | Purpose |
|------|---------|
| `IQuantumService.cs` | Interface for Quantum Leap system |
| `QuantumService.cs` | Implementation wrapping Oracle access |
| `IWorkerService.cs` | Interface for Worker/Influence system |
| `WorkerService.cs` | Implementation wrapping Oracle access |
| `IAvocadoService.cs` | Interface for Avocado aggregator |
| `AvocadoService.cs` | Implementation wrapping Oracle access |
| `ServiceProvider.cs` | Updated to register new services |

### Benefits

- **Decoupled**: Components can depend on interfaces instead of Oracle singleton
- **Testable**: Mock implementations can be provided for unit testing
- **Documented**: Each service has XML documentation explaining purpose and behavior
- **Type-safe**: Strong typing for upgrade types via `QuantumUpgradeType` enum

### Fix Applied

Fixed `WorkerGenerationSpeed` calculation to match existing behavior:
- `prestigePlus.influence` stores the **already-scaled bonus** (each purchase adds +4)
- Removed erroneous multiplication by `InfluenceSpeedPerLevel` that would have caused 4x overcount

## Test plan

- [ ] Code compiles without errors in Unity
- [ ] Services are registered (check Unity console for ServiceProvider logs)
- [ ] Existing functionality unchanged (services wrap existing behavior)
- [ ] Save compatibility maintained (no data changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)