### PR TITLE
feat: Extract AvocadoData from PrestigePlus (Phase 3)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,11 +2,20 @@
   "permissions": {
     "allow": [
       "Bash(*)",
-      "mcp__UnityMCP__*",
       "Edit(*)",
       "Write(*)",
-      "Bash(git -C \"c:\\\\Users\\\\mattr\\\\Documents\\\\Unity\\\\Projects\\\\Idle Dyson Swarm\" add -A)",
-      "Bash(git -C \"c:\\\\Users\\\\mattr\\\\Documents\\\\Unity\\\\Projects\\\\Idle Dyson Swarm\" commit -m \"$\\(cat <<''EOF''\nrefactor: Rename Reality/Quantum files for clarity \\(Phase 4\\)\n\nFile renames:\n- InceptionController.cs → WorkerController.cs\n- PrestigePlusUpdater.cs → QuantumUpgradeUI.cs  \n- ToRealityFillbar.cs → QuantumProgressBar.cs\n\nClass names updated to match file names.\nUpdated comment reference in WorkerService.cs.\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")"
+      "mcp__UnityMCP__*"
+    ],
+    "deny": [
+      "Bash(git * --force *)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -fd*)",
+      "Bash(git branch -D*)",
+      "Bash(rm -rf*)",
+      "Bash(del /s*)",
+      "Bash(rmdir /s*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,16 @@
       "Bash(*)",
       "Edit(*)",
       "Write(*)",
-      "mcp__UnityMCP__*"
+      "mcp__UnityMCP__*",
+      "mcp__UnityMCP__read_console",
+      "Bash(git checkout:*)",
+      "mcp__UnityMCP__refresh_unity",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": [
       "Bash(git * --force *)",

--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -578,7 +578,8 @@ namespace Expansion
                 if (!oracle.saveSettings.infinityInProgress)
                 {
                     oracle.saveSettings.infinityInProgress = true;
-                    prestigePlus.avocatoOverflow++;
+                    oracle.saveSettings.avocadoData.overflowMultiplier++;
+                    prestigePlus.avocatoOverflow++; // Keep legacy field in sync
                     prestigeData.infinityPoints += 1000;
                     _gameManager.Prestige();
                 }

--- a/Assets/Scripts/Services/AvocadoService.cs
+++ b/Assets/Scripts/Services/AvocadoService.cs
@@ -11,15 +11,16 @@ namespace IdleDysonSwarm.Services
     /// </summary>
     public sealed class AvocadoService : IAvocadoService
     {
+        private AvocadoData AvocadoData => StaticSaveSettings.avocadoData;
         private PrestigePlus PrestigePlus => StaticSaveSettings.prestigePlus;
 
         #region State Properties
 
-        public bool IsUnlocked => PrestigePlus.avocatoPurchased;
-        public double AccumulatedIP => PrestigePlus.avocatoIP;
-        public double AccumulatedInfluence => PrestigePlus.avocatoInfluence;
-        public double AccumulatedStrangeMatter => PrestigePlus.avocatoStrangeMatter;
-        public double OverflowMultiplier => PrestigePlus.avocatoOverflow;
+        public bool IsUnlocked => AvocadoData.unlocked;
+        public double AccumulatedIP => AvocadoData.infinityPoints;
+        public double AccumulatedInfluence => AvocadoData.influence;
+        public double AccumulatedStrangeMatter => AvocadoData.strangeMatter;
+        public double OverflowMultiplier => AvocadoData.overflowMultiplier;
 
         #endregion
 
@@ -70,13 +71,23 @@ namespace IdleDysonSwarm.Services
 
         #region Actions
 
+        /// <summary>
+        /// Unlocks the Avocado system. Called when the player purchases the unlock from Quantum upgrades.
+        /// Also sets the legacy field for backward compatibility during the transition period.
+        /// </summary>
+        public void Unlock()
+        {
+            AvocadoData.unlocked = true;
+            PrestigePlus.avocatoPurchased = true; // Keep legacy field in sync
+        }
+
         public void FeedIP(double amount)
         {
             if (amount <= 0 || !IsUnlocked)
                 return;
 
             double previousBuff = GlobalBuff;
-            PrestigePlus.avocatoIP += amount;
+            AvocadoData.infinityPoints += amount;
 
             OnFed?.Invoke();
 
@@ -93,7 +104,7 @@ namespace IdleDysonSwarm.Services
                 return;
 
             double previousBuff = GlobalBuff;
-            PrestigePlus.avocatoInfluence += amount;
+            AvocadoData.influence += amount;
 
             OnFed?.Invoke();
 
@@ -110,7 +121,7 @@ namespace IdleDysonSwarm.Services
                 return;
 
             double previousBuff = GlobalBuff;
-            PrestigePlus.avocatoStrangeMatter += amount;
+            AvocadoData.strangeMatter += amount;
 
             OnFed?.Invoke();
 
@@ -127,7 +138,7 @@ namespace IdleDysonSwarm.Services
                 return;
 
             double previousBuff = GlobalBuff;
-            PrestigePlus.avocatoOverflow += amount;
+            AvocadoData.overflowMultiplier += amount;
 
             OnFed?.Invoke();
 

--- a/Assets/Scripts/Services/IAvocadoService.cs
+++ b/Assets/Scripts/Services/IAvocadoService.cs
@@ -93,6 +93,11 @@ namespace IdleDysonSwarm.Services
         #region Actions
 
         /// <summary>
+        /// Unlocks the Avocado system. Called when the player purchases the unlock from Quantum upgrades.
+        /// </summary>
+        void Unlock();
+
+        /// <summary>
         /// Feeds Infinity Points into the Avocado.
         /// </summary>
         /// <param name="amount">Amount of IP to feed.</param>

--- a/Assets/Scripts/Services/QuantumService.cs
+++ b/Assets/Scripts/Services/QuantumService.cs
@@ -13,6 +13,7 @@ namespace IdleDysonSwarm.Services
     public sealed class QuantumService : IQuantumService
     {
         private PrestigePlus PrestigePlus => StaticSaveSettings.prestigePlus;
+        private AvocadoData AvocadoData => StaticSaveSettings.avocadoData;
         private DysonVersePrestigeData PrestigeData => StaticPrestigeData;
 
         #region State Properties
@@ -197,7 +198,8 @@ namespace IdleDysonSwarm.Services
                     return true;
 
                 case QuantumUpgradeType.Avocado:
-                    PrestigePlus.avocatoPurchased = true;
+                    AvocadoData.unlocked = true;
+                    PrestigePlus.avocatoPurchased = true; // Keep legacy field in sync
                     return true;
 
                 case QuantumUpgradeType.Fragments:

--- a/Assets/Scripts/Services/QuantumService.cs
+++ b/Assets/Scripts/Services/QuantumService.cs
@@ -36,7 +36,7 @@ namespace IdleDysonSwarm.Services
         public bool IsBreakTheLoopUnlocked => PrestigePlus.breakTheLoop;
         public bool IsQuantumEntanglementUnlocked => PrestigePlus.quantumEntanglement;
         public bool IsAutomationUnlocked => PrestigePlus.automation;
-        public bool IsAvocadoUnlocked => PrestigePlus.avocatoPurchased;
+        public bool IsAvocadoUnlocked => AvocadoData.unlocked;
         public bool IsFragmentsUnlocked => PrestigePlus.fragments;
         public bool IsPurityUnlocked => PrestigePlus.purity;
         public bool IsTerraUnlocked => PrestigePlus.terra;

--- a/Assets/Scripts/Systems/Avocado/AvocadoFeeder.cs
+++ b/Assets/Scripts/Systems/Avocado/AvocadoFeeder.cs
@@ -9,7 +9,7 @@ using static IdleDysonSwarm.Systems.Constants.RealityConstants;
 
 public class AvocadoFeeder : MonoBehaviour
 {
-    private PrestigePlus prestigePlus => oracle.saveSettings.prestigePlus;
+    private AvocadoData avocadoData => oracle.saveSettings.avocadoData;
     private DysonVersePrestigeData prestigeData => oracle.saveSettings.dysonVerseSaveData.dysonVersePrestigeData;
     private SaveDataPrestige saveDataPrestige => oracle.saveSettings.sdPrestige;
     private SaveData saveData => oracle.saveSettings.saveData;
@@ -36,7 +36,7 @@ public class AvocadoFeeder : MonoBehaviour
         if (prestigeData.infinityPoints - prestigeData.spentInfinityPoints > 0)
         {
             long availableInfinityPoints = prestigeData.infinityPoints - prestigeData.spentInfinityPoints;
-            prestigePlus.avocatoIP += availableInfinityPoints;
+            avocadoData.infinityPoints += availableInfinityPoints;
             prestigeData.infinityPoints -= availableInfinityPoints;
             UpdateText();
         }
@@ -46,7 +46,7 @@ public class AvocadoFeeder : MonoBehaviour
     {
         if (saveData.influence > 0)
         {
-            prestigePlus.avocatoInfluence += saveData.influence;
+            avocadoData.influence += saveData.influence;
             saveData.influence = 0;
             UpdateText();
         }
@@ -56,7 +56,7 @@ public class AvocadoFeeder : MonoBehaviour
     {
         if (saveDataPrestige.strangeMatter > 0)
         {
-            prestigePlus.avocatoStrangeMatter += saveDataPrestige.strangeMatter;
+            avocadoData.strangeMatter += saveDataPrestige.strangeMatter;
             saveDataPrestige.strangeMatter = 0;
             UpdateText();
         }
@@ -64,11 +64,11 @@ public class AvocadoFeeder : MonoBehaviour
 
     public void UpdateText()
     {
-        gameObject.SetActive(prestigePlus.avocatoPurchased);
-        double infinityPointsMultiplier = prestigePlus.avocatoIP >= AvocadoLogThreshold ? Math.Log10(prestigePlus.avocatoIP) : 0;
-        double influenceMultiplier = prestigePlus.avocatoInfluence >= AvocadoLogThreshold ? Math.Log10(prestigePlus.avocatoInfluence) : 0;
-        double strangeMatterMultiplier = prestigePlus.avocatoStrangeMatter >= AvocadoLogThreshold ? Math.Log10(prestigePlus.avocatoStrangeMatter) : 0;
-        double overflowMultiplier = 1 + prestigePlus.avocatoOverflow;
+        gameObject.SetActive(avocadoData.unlocked);
+        double infinityPointsMultiplier = avocadoData.infinityPoints >= AvocadoLogThreshold ? Math.Log10(avocadoData.infinityPoints) : 0;
+        double influenceMultiplier = avocadoData.influence >= AvocadoLogThreshold ? Math.Log10(avocadoData.influence) : 0;
+        double strangeMatterMultiplier = avocadoData.strangeMatter >= AvocadoLogThreshold ? Math.Log10(avocadoData.strangeMatter) : 0;
+        double overflowMultiplier = 1 + avocadoData.overflowMultiplier;
 
         feedInfinityPointsText.text =
             $"Infinity Multiplier - <color=#00E1FF>x{CalcUtils.FormatNumber(infinityPointsMultiplier)}";

--- a/Assets/Scripts/Systems/Migrations/MigrationContext.cs
+++ b/Assets/Scripts/Systems/Migrations/MigrationContext.cs
@@ -19,5 +19,7 @@ namespace Systems.Migrations
         public Oracle.DysonVerseInfinityData InfinityData => DysonVerseSaveData?.dysonVerseInfinityData;
         public Oracle.DysonVersePrestigeData PrestigeData => DysonVerseSaveData?.dysonVersePrestigeData;
         public Oracle.DysonVerseSkillTreeData SkillTreeData => DysonVerseSaveData?.dysonVerseSkillTreeData;
+        public Oracle.PrestigePlus PrestigePlus => SaveData?.prestigePlus;
+        public Oracle.AvocadoData AvocadoData => SaveData?.avocadoData;
     }
 }

--- a/Assets/Scripts/Systems/Migrations/MigrationSnapshot.cs
+++ b/Assets/Scripts/Systems/Migrations/MigrationSnapshot.cs
@@ -25,6 +25,20 @@ namespace Systems.Migrations
         public double SuperRadiantScatteringTimer { get; private set; }
         public double IdleElectricSheepTimer { get; private set; }
 
+        // AvocadoData tracking (Phase 3 migration)
+        public bool AvocadoUnlocked { get; private set; }
+        public double AvocadoInfinityPoints { get; private set; }
+        public double AvocadoInfluence { get; private set; }
+        public double AvocadoStrangeMatter { get; private set; }
+        public double AvocadoOverflowMultiplier { get; private set; }
+
+        // Legacy avocato fields (pre-migration)
+        public bool LegacyAvocatoPurchased { get; private set; }
+        public double LegacyAvocatoIP { get; private set; }
+        public double LegacyAvocatoInfluence { get; private set; }
+        public double LegacyAvocatoStrangeMatter { get; private set; }
+        public double LegacyAvocatoOverflow { get; private set; }
+
         public static MigrationSnapshot Capture(Oracle.SaveDataSettings saveData)
         {
             var snapshot = new MigrationSnapshot
@@ -78,6 +92,28 @@ namespace Systems.Migrations
                 snapshot.PocketAndroidsTimer = Oracle.GetSkillTimerSeconds(infinityData, "pocketAndroids");
                 snapshot.SuperRadiantScatteringTimer = Oracle.GetSkillTimerSeconds(infinityData, "superRadiantScattering");
                 snapshot.IdleElectricSheepTimer = Oracle.GetSkillTimerSeconds(infinityData, "idleElectricSheep");
+            }
+
+            // Capture AvocadoData state
+            Oracle.AvocadoData avocadoData = saveData.avocadoData;
+            if (avocadoData != null)
+            {
+                snapshot.AvocadoUnlocked = avocadoData.unlocked;
+                snapshot.AvocadoInfinityPoints = avocadoData.infinityPoints;
+                snapshot.AvocadoInfluence = avocadoData.influence;
+                snapshot.AvocadoStrangeMatter = avocadoData.strangeMatter;
+                snapshot.AvocadoOverflowMultiplier = avocadoData.overflowMultiplier;
+            }
+
+            // Capture legacy avocato fields (for verifying migration)
+            Oracle.PrestigePlus prestigePlus = saveData.prestigePlus;
+            if (prestigePlus != null)
+            {
+                snapshot.LegacyAvocatoPurchased = prestigePlus.avocatoPurchased;
+                snapshot.LegacyAvocatoIP = prestigePlus.avocatoIP;
+                snapshot.LegacyAvocatoInfluence = prestigePlus.avocatoInfluence;
+                snapshot.LegacyAvocatoStrangeMatter = prestigePlus.avocatoStrangeMatter;
+                snapshot.LegacyAvocatoOverflow = prestigePlus.avocatoOverflow;
             }
 
             return snapshot;
@@ -142,6 +178,39 @@ namespace Systems.Migrations
                     $"pocket: {FormatDouble(before.PocketAndroidsTimer)} -> {FormatDouble(PocketAndroidsTimer)}, " +
                     $"superRadiant: {FormatDouble(before.SuperRadiantScatteringTimer)} -> {FormatDouble(SuperRadiantScatteringTimer)}, " +
                     $"idleSheep: {FormatDouble(before.IdleElectricSheepTimer)} -> {FormatDouble(IdleElectricSheepTimer)}";
+            }
+
+            // AvocadoData migration tracking
+            if (AvocadoUnlocked != before.AvocadoUnlocked)
+            {
+                yield return $"avocadoData.unlocked: {before.AvocadoUnlocked} -> {AvocadoUnlocked}";
+            }
+
+            if (!NearlyEqual(AvocadoInfinityPoints, before.AvocadoInfinityPoints) ||
+                !NearlyEqual(AvocadoInfluence, before.AvocadoInfluence) ||
+                !NearlyEqual(AvocadoStrangeMatter, before.AvocadoStrangeMatter) ||
+                !NearlyEqual(AvocadoOverflowMultiplier, before.AvocadoOverflowMultiplier))
+            {
+                yield return
+                    $"avocadoData: IP {FormatDouble(before.AvocadoInfinityPoints)} -> {FormatDouble(AvocadoInfinityPoints)}, " +
+                    $"influence {FormatDouble(before.AvocadoInfluence)} -> {FormatDouble(AvocadoInfluence)}, " +
+                    $"strangeMatter {FormatDouble(before.AvocadoStrangeMatter)} -> {FormatDouble(AvocadoStrangeMatter)}, " +
+                    $"overflow {FormatDouble(before.AvocadoOverflowMultiplier)} -> {FormatDouble(AvocadoOverflowMultiplier)}";
+            }
+
+            // Legacy avocato fields (should be zeroed after migration)
+            if (LegacyAvocatoPurchased != before.LegacyAvocatoPurchased ||
+                !NearlyEqual(LegacyAvocatoIP, before.LegacyAvocatoIP) ||
+                !NearlyEqual(LegacyAvocatoInfluence, before.LegacyAvocatoInfluence) ||
+                !NearlyEqual(LegacyAvocatoStrangeMatter, before.LegacyAvocatoStrangeMatter) ||
+                !NearlyEqual(LegacyAvocatoOverflow, before.LegacyAvocatoOverflow))
+            {
+                yield return
+                    $"legacy avocato: purchased {before.LegacyAvocatoPurchased} -> {LegacyAvocatoPurchased}, " +
+                    $"IP {FormatDouble(before.LegacyAvocatoIP)} -> {FormatDouble(LegacyAvocatoIP)}, " +
+                    $"influence {FormatDouble(before.LegacyAvocatoInfluence)} -> {FormatDouble(LegacyAvocatoInfluence)}, " +
+                    $"strangeMatter {FormatDouble(before.LegacyAvocatoStrangeMatter)} -> {FormatDouble(LegacyAvocatoStrangeMatter)}, " +
+                    $"overflow {FormatDouble(before.LegacyAvocatoOverflow)} -> {FormatDouble(LegacyAvocatoOverflow)}";
             }
         }
 

--- a/Assets/Scripts/Systems/ModifierSystem.cs
+++ b/Assets/Scripts/Systems/ModifierSystem.cs
@@ -557,7 +557,21 @@ namespace Systems
             }
         }
 
+        /// <summary>
+        /// Calculates the global buff multiplier from skill tree bonuses and Avocado contributions.
+        /// </summary>
+        /// <remarks>
+        /// Legacy overload that uses StaticSaveSettings.avocadoData for backward compatibility.
+        /// </remarks>
         public static double GlobalBuff(DysonVerseInfinityData infinityData, DysonVerseSkillTreeData skillTreeData, PrestigePlus prestigePlus)
+        {
+            return GlobalBuff(infinityData, skillTreeData, StaticSaveSettings?.avocadoData ?? new AvocadoData());
+        }
+
+        /// <summary>
+        /// Calculates the global buff multiplier from skill tree bonuses and Avocado contributions.
+        /// </summary>
+        public static double GlobalBuff(DysonVerseInfinityData infinityData, DysonVerseSkillTreeData skillTreeData, AvocadoData avocadoData)
         {
             double multi = 1f;
             if (skillTreeData.purityOfSEssence && skillTreeData.skillPointsTree > 0) multi *= 1.42f * skillTreeData.skillPointsTree;
@@ -566,16 +580,16 @@ namespace Systems
                 double scatteringTimer = GetSkillTimerSeconds(infinityData, "superRadiantScattering");
                 multi *= 1 + 0.01f * scatteringTimer;
             }
-            if (prestigePlus.avocatoPurchased)
+            if (avocadoData != null && avocadoData.unlocked)
             {
-                if (prestigePlus.avocatoIP >= AvocadoLogThreshold)
-                    multi *= Math.Log10(prestigePlus.avocatoIP);
-                if (prestigePlus.avocatoInfluence >= AvocadoLogThreshold)
-                    multi *= Math.Log10(prestigePlus.avocatoInfluence);
-                if (prestigePlus.avocatoStrangeMatter >= AvocadoLogThreshold)
-                    multi *= Math.Log10(prestigePlus.avocatoStrangeMatter);
-                if (prestigePlus.avocatoOverflow >= 1)
-                    multi *= 1 + prestigePlus.avocatoOverflow;
+                if (avocadoData.infinityPoints >= AvocadoLogThreshold)
+                    multi *= Math.Log10(avocadoData.infinityPoints);
+                if (avocadoData.influence >= AvocadoLogThreshold)
+                    multi *= Math.Log10(avocadoData.influence);
+                if (avocadoData.strangeMatter >= AvocadoLogThreshold)
+                    multi *= Math.Log10(avocadoData.strangeMatter);
+                if (avocadoData.overflowMultiplier >= 1)
+                    multi *= 1 + avocadoData.overflowMultiplier;
             }
 
             return multi;

--- a/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs
+++ b/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs
@@ -527,17 +527,19 @@ namespace Systems.Stats
         private static void AddAvocatoMultiplier(List<StatEffect> effects, string statId, PrestigePlus prestigePlus, string id,
             int order)
         {
-            if (effects == null || prestigePlus == null || !prestigePlus.avocatoPurchased) return;
+            // Use AvocadoData for the actual values (migration moves data there)
+            AvocadoData avocadoData = StaticSaveSettings?.avocadoData;
+            if (effects == null || avocadoData == null || !avocadoData.unlocked) return;
 
             double multi = 1;
-            if (prestigePlus.avocatoIP >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoIP);
-            if (prestigePlus.avocatoInfluence >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoInfluence);
-            if (prestigePlus.avocatoStrangeMatter >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoStrangeMatter);
-            if (prestigePlus.avocatoOverflow >= 1)
-                multi *= 1 + prestigePlus.avocatoOverflow;
+            if (avocadoData.infinityPoints >= 10)
+                multi *= Math.Log10(avocadoData.infinityPoints);
+            if (avocadoData.influence >= 10)
+                multi *= Math.Log10(avocadoData.influence);
+            if (avocadoData.strangeMatter >= 10)
+                multi *= Math.Log10(avocadoData.strangeMatter);
+            if (avocadoData.overflowMultiplier >= 1)
+                multi *= 1 + avocadoData.overflowMultiplier;
 
             AddMultiplierEffect(effects, id, "Avocato Multiplier", statId, multi, order);
         }

--- a/Assets/Scripts/Systems/Stats/GlobalStatPipeline.cs
+++ b/Assets/Scripts/Systems/Stats/GlobalStatPipeline.cs
@@ -211,17 +211,19 @@ namespace Systems.Stats
         private static void AddAvocatoMultiplier(List<StatEffect> effects, string targetStatId, PrestigePlus prestigePlus,
             int order)
         {
-            if (prestigePlus == null || !prestigePlus.avocatoPurchased) return;
+            // Use AvocadoData for the actual values (migration moves data there)
+            AvocadoData avocadoData = StaticSaveSettings?.avocadoData;
+            if (avocadoData == null || !avocadoData.unlocked) return;
 
             double multi = 1;
-            if (prestigePlus.avocatoIP >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoIP);
-            if (prestigePlus.avocatoInfluence >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoInfluence);
-            if (prestigePlus.avocatoStrangeMatter >= 10)
-                multi *= Math.Log10(prestigePlus.avocatoStrangeMatter);
-            if (prestigePlus.avocatoOverflow >= 1)
-                multi *= 1 + prestigePlus.avocatoOverflow;
+            if (avocadoData.infinityPoints >= 10)
+                multi *= Math.Log10(avocadoData.infinityPoints);
+            if (avocadoData.influence >= 10)
+                multi *= Math.Log10(avocadoData.influence);
+            if (avocadoData.strangeMatter >= 10)
+                multi *= Math.Log10(avocadoData.strangeMatter);
+            if (avocadoData.overflowMultiplier >= 1)
+                multi *= 1 + avocadoData.overflowMultiplier;
 
             AddMultiplierEffect(effects, "prestige.avocato_multiplier", "Avocato Multiplier", targetStatId, multi,
                 order);

--- a/Assets/Scripts/User Interface/QuantumUpgradeUI.cs
+++ b/Assets/Scripts/User Interface/QuantumUpgradeUI.cs
@@ -64,7 +64,7 @@ public class QuantumUpgradeUI : MonoBehaviour
             prestigePlus.divisionsPurchased >= 19 ? "Purchased" : $"{CalcUtils.FormatNumber(divisionCost)}<sprite=5, color=#000000>";
 
         avocatoButton.onClick.AddListener(PurchaseAvocato);
-        if (prestigePlus.avocatoPurchased) avocatoButton.transform.GetComponentInChildren<TMP_Text>().text = "Purchased";
+        if (avocadoData.unlocked) avocatoButton.transform.GetComponentInChildren<TMP_Text>().text = "Purchased";
 
         breakTheLoopButton.onClick.AddListener(PurchaseBreakTheLoop);
         if (prestigePlus.breakTheLoop) breakTheLoopButton.transform.GetComponentInChildren<TMP_Text>().text = "Purchased";
@@ -123,7 +123,7 @@ public class QuantumUpgradeUI : MonoBehaviour
         divisionButton.interactable = !(prestigePlus.divisionsPurchased >= 19) && prestigePlus.points - prestigePlus.spentPoints >= divisionCost &&
                                       prestigePlus.botMultitasking && prestigePlus.doubleIP;
 
-        avocatoButton.interactable = !prestigePlus.avocatoPurchased && pointsRemaining >= AvocadoCost;
+        avocatoButton.interactable = !avocadoData.unlocked && pointsRemaining >= AvocadoCost;
 
         breakTheLoopButton.interactable = !prestigePlus.breakTheLoop && pointsRemaining >= BreakTheLoopCost;
         quantumEntanglementButton.interactable = !prestigePlus.quantumEntanglement && pointsRemaining >= QuantumEntanglementCost;

--- a/Assets/Scripts/User Interface/QuantumUpgradeUI.cs
+++ b/Assets/Scripts/User Interface/QuantumUpgradeUI.cs
@@ -38,6 +38,7 @@ public class QuantumUpgradeUI : MonoBehaviour
 
     private int divisionCost => prestigePlus.divisionsPurchased >= 1 ? (int)Math.Pow(2, prestigePlus.divisionsPurchased) * 2 : 2;
     private PrestigePlus prestigePlus => oracle.saveSettings.prestigePlus;
+    private AvocadoData avocadoData => oracle.saveSettings.avocadoData;
     private DysonVerseInfinityData infinityData => oracle.saveSettings.dysonVerseSaveData.dysonVerseInfinityData;
     private DysonVersePrestigeData prestigeData => oracle.saveSettings.dysonVerseSaveData.dysonVersePrestigeData;
     private DysonVerseSaveData dysonVerseSaveData => oracle.saveSettings.dysonVerseSaveData;
@@ -139,7 +140,8 @@ public class QuantumUpgradeUI : MonoBehaviour
     {
         if (pointsRemaining < AvocadoCost) return;
         avocatoButton.transform.GetComponentInChildren<TMP_Text>().text = "Purchased";
-        prestigePlus.avocatoPurchased = true;
+        avocadoData.unlocked = true;
+        prestigePlus.avocatoPurchased = true; // Keep legacy field in sync
         prestigePlus.spentPoints += AvocadoCost;
     }
 


### PR DESCRIPTION
## Summary

- Create new `AvocadoData` class to hold cross-system aggregator state, extracted from legacy `avocato*` fields in `PrestigePlus`
- Add migration step (version 5) to migrate existing saves
- Update all Avocado-related code to use new data structure while keeping legacy fields in sync

## Changes

| File | Description |
|------|-------------|
| `Oracle.cs` | Add `AvocadoData` class, add to `SaveDataSettings`, add migration v5, update `CurrentSaveVersion` to 5, fix overflow increment |
| `AvocadoService.cs` | Use `AvocadoData`, add `Unlock()` method |
| `IAvocadoService.cs` | Add `Unlock()` to interface |
| `AvocadoFeeder.cs` | Use `avocadoData` instead of `prestigePlus.avocato*` |
| `ModifierSystem.cs` | Add backward-compatible `GlobalBuff()` overload |
| `MigrationSnapshot.cs` | Track both new and legacy Avocado fields |
| `MigrationContext.cs` | Expose `PrestigePlus` and `AvocadoData` |
| `QuantumService.cs` | Use `AvocadoData.unlocked` for unlock check, set both fields on purchase |
| `QuantumUpgradeUI.cs` | Use `avocadoData.unlocked` for button state, set both fields on purchase |
| `GlobalStatPipeline.cs` | Use `AvocadoData` instead of zeroed legacy fields |
| `FacilityModifierPipeline.cs` | Use `AvocadoData` instead of zeroed legacy fields |

## Migration Strategy

- New saves use `AvocadoData` directly
- Old saves migrated via version 5 migration step
- Legacy `PrestigePlus.avocato*` fields kept in sync for backward compatibility
- Migration clears legacy fields after copying to prevent double-counting

## Fixes Applied

1. **Pipeline fix (f8e5b74)**: `GlobalStatPipeline.AddAvocatoMultiplier` and `FacilityModifierPipeline.AddAvocatoMultiplier` were reading from legacy fields that get zeroed after migration.

2. **Unlock check fix (a8fb3fd)**: `QuantumService.IsAvocadoUnlocked` and `QuantumUpgradeUI` button state checks were reading from `PrestigePlus.avocatoPurchased` instead of `AvocadoData.unlocked`.

## Test plan

- [ ] Verify Unity compilation (no errors or warnings)
- [ ] Test new game - Avocado purchase works
- [ ] Test existing save - Avocado data migrated correctly
- [ ] Test Avocado feeding (IP, Influence, Strange Matter)
- [ ] Verify global buff calculation unchanged
- [ ] Verify facility buffs work after migration
- [ ] Verify Avocado button shows "Purchased" after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)