### PR TITLE
refactor: Consolidate UI logic using services (Phase 5)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,10 @@
       "Bash(git push:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr edit:*)",
-      "Bash(gh pr view:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git pull:*)",
+      "Bash(git stash:*)"
     ],
     "deny": [
       "Bash(git * --force *)",

--- a/Assets/Scripts/Systems/Infinity/InfinityManager.cs
+++ b/Assets/Scripts/Systems/Infinity/InfinityManager.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 using UnityEngine.Serialization;
 using Blindsided.Utilities;
 using static Expansion.Oracle;
+using static IdleDysonSwarm.Systems.Constants.QuantumConstants;
 
 public class InfinityManager : MonoBehaviour
 {
@@ -43,7 +44,7 @@ public class InfinityManager : MonoBehaviour
     private readonly int autoResearchCost = 3;
     private readonly int autoBotsCost = 3;
 
-    private readonly int maxSecrets = 27;
+    private readonly int maxSecrets = MaxSecrets;
     private readonly int maxSkills = 10;
 
     private DysonVerseInfinityData infinityData => oracle.saveSettings.dysonVerseSaveData.dysonVerseInfinityData;
@@ -255,7 +256,7 @@ public class InfinityManager : MonoBehaviour
 
     public void PurchaseSecret()
     {
-        if (prestigeData.secretsOfTheUniverse >= 27) return;
+        if (prestigeData.secretsOfTheUniverse >= maxSecrets) return;
         prestigeData.spentInfinityPoints += 1;
         prestigeData.secretsOfTheUniverse += 1;
     }

--- a/Assets/Scripts/Systems/StoryManager.cs
+++ b/Assets/Scripts/Systems/StoryManager.cs
@@ -1,6 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using IdleDysonSwarm.Services;
 using static Expansion.Oracle;
 
 public class StoryManager : MonoBehaviour
@@ -48,6 +47,12 @@ public class StoryManager : MonoBehaviour
     [SerializeField] private GameObject C6C2;
     [SerializeField] private GameObject C6C3;
     private PrestigePlus prestigePlus => oracle.saveSettings.prestigePlus;
+    private IWorkerService _workerService;
+
+    private void Awake()
+    {
+        _workerService = ServiceLocator.Get<IWorkerService>();
+    }
 
     private void Update()
     {
@@ -80,12 +85,13 @@ public class StoryManager : MonoBehaviour
         C4C9.SetActive(infinityCount >= 8 || leap);
         C4C10.SetActive(infinityCount >= 9 || leap);
 
-        C5.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
-        C5C1.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
-        C5C2.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
-        C5C3.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
-        C5C4.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
-        C5C5.SetActive(prestigeData.secretsOfTheUniverse >= 27 || leap);
+        bool realityUnlocked = _workerService.IsRealityUnlocked;
+        C5.SetActive(realityUnlocked);
+        C5C1.SetActive(realityUnlocked);
+        C5C2.SetActive(realityUnlocked);
+        C5C3.SetActive(realityUnlocked);
+        C5C4.SetActive(realityUnlocked);
+        C5C5.SetActive(realityUnlocked);
 
         C6.SetActive(sp.translation8);
         C6C1.SetActive(sp.translation8);

--- a/Assets/Scripts/User Interface/RealityPanelManager.cs
+++ b/Assets/Scripts/User Interface/RealityPanelManager.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using Blindsided.Utilities;
+using IdleDysonSwarm.Services;
 using static Expansion.Oracle;
 using static IdleDysonSwarm.Systems.Constants.QuantumConstants;
 
@@ -28,6 +29,7 @@ public class RealityPanelManager : MonoBehaviour
     private SlicedFilledImage _realityUnlockFill;
     private TMP_Text _realityText;
     private Button _realityMenuButton;
+    private IWorkerService _workerService;
 
     /// <summary>
     /// Public accessor for backward compatibility with DebugOptions and Oracle.
@@ -45,6 +47,8 @@ public class RealityPanelManager : MonoBehaviour
 
     private void Awake()
     {
+        _workerService = ServiceLocator.Get<IWorkerService>();
+
         if (_realityUnlockFillObject != null)
             _realityUnlockFill = _realityUnlockFillObject.GetComponent<SlicedFilledImage>();
         if (_realityTextObject != null)
@@ -67,8 +71,7 @@ public class RealityPanelManager : MonoBehaviour
         _reality.SetActive(show);
         if (!show) return;
 
-        bool unlocked = PrestigePlus.points >= 1
-            || PrestigeData.secretsOfTheUniverse >= MaxSecrets
+        bool unlocked = _workerService.IsRealityUnlocked
             || oracle.saveSettings.unlockAllTabs;
 
         _realityImage.SetActive(unlocked);


### PR DESCRIPTION
## Summary

Phase 5 of the Quantum/Reality refactor - consolidates duplicate UI logic by using service layer properties.

### Changes

- **RealityPanelManager**: Use `IWorkerService.IsRealityUnlocked` instead of direct `PrestigePlus.points >= 1 || secretsOfTheUniverse >= 27` checks
- **WorkerController**: Use `IWorkerService` for:
  - `WorkerFillPercent` (replaces manual `workersReadyToGo / 128f` calculation)
  - `CanGather` (replaces `workersReadyToGo >= 128` checks)
  - `AutoGatherEnabled` (replaces `workerAutoConvert` direct access)
  - `WorkerGenerationSpeed`, `InfluenceBalance`, `WorkersReady`, `WorkerBatchesProcessed`
- **StoryManager**: Use `IWorkerService.IsRealityUnlocked` for C5 panel visibility (6 places consolidated)
- **InfinityManager**: Use `MaxSecrets` constant consistently instead of hardcoded `27`

### Benefits

- Centralizes Reality unlock logic in one place (`WorkerService.IsRealityUnlocked`)
- Reduces code duplication across UI components
- Makes it easier to modify unlock conditions in the future
- Better separation of concerns (UI reads from service, doesn't calculate itself)

## Test plan
- [ ] Verify compilation succeeds (no errors in Unity console)
- [ ] Reality panel shows/hides correctly based on Quantum points or 27 secrets
- [ ] Worker fill bars display correctly
- [ ] Story elements (C5 panels) show correctly when Reality is unlocked
- [ ] Secrets purchase works correctly in Infinity panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)