### PR TITLE
fix: Close facility breakdown popup when switching tabs

### DIFF
--- a/Assets/Scripts/Systems/Facilities/FacilityBreakdownPopup.cs
+++ b/Assets/Scripts/Systems/Facilities/FacilityBreakdownPopup.cs
@@ -15,6 +15,11 @@ namespace Systems.Facilities
 {
     public sealed class FacilityBreakdownPopup : MonoBehaviour
     {
+        /// <summary>
+        /// Static instance for global access (e.g., closing popup on tab switch).
+        /// </summary>
+        public static FacilityBreakdownPopup Instance { get; private set; }
+
         // Rich text color tags matching UITheme colors
         private const string ColorDelta = "<color=#FFA45E>"; // Orange (accent) for positive delta
         private const string ColorNegative = "<color=#FF5757>"; // Red (negative) for negative delta
@@ -34,6 +39,8 @@ namespace Systems.Facilities
 
         private void Awake()
         {
+            Instance = this;
+
             if (root == null)
             {
                 root = gameObject;

--- a/Assets/Scripts/User Interface/ButtonThings.cs
+++ b/Assets/Scripts/User Interface/ButtonThings.cs
@@ -1,3 +1,4 @@
+using Systems.Facilities;
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -89,6 +90,10 @@ public class ButtonThings : MonoBehaviour
 
     public void GroupEnableDisableMenu()
     {
+        // Close any open facility breakdown popup when switching tabs
+        if (FacilityBreakdownPopup.Instance != null)
+            FacilityBreakdownPopup.Instance.Hide();
+
         for (int i = 0; i < _groupDisable.ToDisable.Length; i++) _groupDisable.ToDisable[i].SetActive(false);
         for (int i = 0; i < _groupDisable.ToEnable.Length; i++) _groupDisable.ToEnable[i].SetActive(true);
         GroupEnable();


### PR DESCRIPTION
## Summary
- Fixes the facility breakdown popup staying visible when switching to other tabs
- Adds static `Instance` property to `FacilityBreakdownPopup` for global access
- Calls `Hide()` in `ButtonThings.GroupEnableDisableMenu()` before tab switch occurs

## Test plan
- [ ] Open the facility breakdown popup (click info button on any facility)
- [ ] Switch to a different tab (e.g., Research, Skills)
- [ ] Verify the popup automatically closes when the tab switches
- [ ] Verify popup still closes correctly via close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)