### PR TITLE
fix: Prevent scroll wheel from scrolling while zooming in PinchableScrollRect

### DIFF
--- a/Assets/Scripts/Systems/PinchableScrollRect.cs
+++ b/Assets/Scripts/Systems/PinchableScrollRect.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.EnhancedTouch;
 using UnityEngine.UI;
@@ -82,6 +83,11 @@ public class PinchableScrollRect : ScrollRect
     {
         if (_isPincching || blockPan) return;
         base.SetContentAnchoredPosition(position);
+    }
+
+    public override void OnScroll(PointerEventData eventData)
+    {
+        // Don't pass scroll to base class - we handle mouse wheel for zooming in Update()
     }
 
     private void OnPinchStart()


### PR DESCRIPTION
## Summary
- Fixes the skill tree scrolling up/down when using mouse wheel to zoom
- Overrides `OnScroll` to block the base `ScrollRect` from handling scroll events
- Mouse wheel is already handled in `Update()` for zooming, so the base class scroll behavior was causing double-handling

## Test plan
- [ ] Open the skill tree panel
- [ ] Use mouse wheel to zoom in/out
- [ ] Verify the view zooms without also scrolling up/down
- [ ] Verify touch pinch-to-zoom still works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)