### PR TITLE
Guard empty quit timestamps before offline calc

### DIFF
--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -3617,6 +3617,7 @@ namespace Expansion
 
         private void AwayForSeconds()
         {
+            if (string.IsNullOrEmpty(oracle.saveSettings.dateQuitString)) return;
             DateTime dateStarted;
             if (!DateTime.TryParse(oracle.saveSettings.dateQuitString, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out dateStarted))


### PR DESCRIPTION
## Summary
- skip offline-time calculation when dateQuitString is empty to avoid granting entire save age

## Testing
- not run