### PR TITLE
Remove redundant skill preset save/load hooks

### DIFF
--- a/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
+++ b/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
@@ -12,36 +12,25 @@ public class SkillTreeSettingsManager : MonoBehaviour
     [SerializeField] private GameManager _gameManager;
     [SerializeField] private SkillTreeManager _skillTreeManager;
     [SerializeField] private TMP_Text feedbackMessage;
-    [SerializeField] private Button preset1Save;
-    [SerializeField] private Button preset1Load;
-    [SerializeField] private Button preset2Save;
-    [SerializeField] private Button preset2Load;
-    [SerializeField] private Button preset3Save;
-    [SerializeField] private Button preset3Load;
-    [SerializeField] private Button preset4Save;
-    [SerializeField] private Button preset4Load;
-    [SerializeField] private Button preset5Save;
-    [SerializeField] private Button preset5Load;
-    [Header("Preset Clipboard (Designers: wire these to UI if you want clipboard import/export)")]
-    [SerializeField, Tooltip("Copy preset to clipboard as JSON for sharing.")]
+    [SerializeField]
     private Button preset1Export;
-    [SerializeField, Tooltip("Paste preset JSON from clipboard into preset slot.")]
+    [SerializeField]
     private Button preset1Import;
-    [SerializeField, Tooltip("Copy preset to clipboard as JSON for sharing.")]
+    [SerializeField]
     private Button preset2Export;
-    [SerializeField, Tooltip("Paste preset JSON from clipboard into preset slot.")]
+    [SerializeField]
     private Button preset2Import;
-    [SerializeField, Tooltip("Copy preset to clipboard as JSON for sharing.")]
+    [SerializeField]
     private Button preset3Export;
-    [SerializeField, Tooltip("Paste preset JSON from clipboard into preset slot.")]
+    [SerializeField]
     private Button preset3Import;
-    [SerializeField, Tooltip("Copy preset to clipboard as JSON for sharing.")]
+    [SerializeField]
     private Button preset4Export;
-    [SerializeField, Tooltip("Paste preset JSON from clipboard into preset slot.")]
+    [SerializeField]
     private Button preset4Import;
-    [SerializeField, Tooltip("Copy preset to clipboard as JSON for sharing.")]
+    [SerializeField]
     private Button preset5Export;
-    [SerializeField, Tooltip("Paste preset JSON from clipboard into preset slot.")]
+    [SerializeField]
     private Button preset5Import;
     [SerializeField] private Button preset1Set;
     [SerializeField] private Button preset2Set;
@@ -75,31 +64,6 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
     private void Start()
     {
-        preset1Save.onClick.AddListener(() => SetFeedbackText("Preset 1 Saved"));
-        preset1Save.onClick.AddListener(() => SavePreset(1));
-        preset1Load.onClick.AddListener(() => SetFeedbackText("Preset 1 Loaded"));
-        preset1Load.onClick.AddListener(() => LoadPreset(1));
-
-        preset2Save.onClick.AddListener(() => SetFeedbackText("Preset 2 Saved"));
-        preset2Save.onClick.AddListener(() => SavePreset(2));
-        preset2Load.onClick.AddListener(() => SetFeedbackText("Preset 2 Loaded"));
-        preset2Load.onClick.AddListener(() => LoadPreset(2));
-
-        preset3Save.onClick.AddListener(() => SetFeedbackText("Preset 3 Saved"));
-        preset3Save.onClick.AddListener(() => SavePreset(3));
-        preset3Load.onClick.AddListener(() => SetFeedbackText("Preset 3 Loaded"));
-        preset3Load.onClick.AddListener(() => LoadPreset(3));
-
-        preset4Save.onClick.AddListener(() => SetFeedbackText("Preset 4 Saved"));
-        preset4Save.onClick.AddListener(() => SavePreset(4));
-        preset4Load.onClick.AddListener(() => SetFeedbackText("Preset 4 Loaded"));
-        preset4Load.onClick.AddListener(() => LoadPreset(4));
-
-        preset5Save.onClick.AddListener(() => SetFeedbackText("Preset 5 Saved"));
-        preset5Save.onClick.AddListener(() => SavePreset(5));
-        preset5Load.onClick.AddListener(() => SetFeedbackText("Preset 5 Loaded"));
-        preset5Load.onClick.AddListener(() => LoadPreset(5));
-
         WirePresetClipboardButtons(preset1Export, preset1Import, 1);
         WirePresetClipboardButtons(preset2Export, preset2Import, 2);
         WirePresetClipboardButtons(preset3Export, preset3Import, 3);


### PR DESCRIPTION
## Summary
- drop the obsolete preset save/load button references and wiring now that swaps trigger autosaves
- keep only the import/export clipboard wiring and preset slot buttons so the UI reflects the new flow

## Testing
- Not run (not requested)