### PR TITLE
Add configurable progress bar flicker manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This file is a lightweight, human-readable map of the project so future agents can orient quickly.
 
+## Clarifying questions (required)
+Do not make assumptions.
+
+If a request, requirement, expected behavior, acceptance criteria, asset reference, platform target, build step, or test/verification approach is ambiguous or underspecified, stop and ask the user clarifying questions before changing code/content.
+
+If multiple interpretations are plausible, enumerate the competing interpretations briefly and ask which one is intended.
+
 ## Project structure (high level)
 
 ### Root

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -41575,7 +41575,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -899.1198, y: 31}
+  m_AnchoredPosition: {x: -899.11975, y: 31}
   m_SizeDelta: {x: 0, y: 55}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &223457327
@@ -79001,6 +79001,11 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5781355219342884152, guid: 98222156e02dd51479ae310daf2626b9, type: 3}
   m_PrefabInstance: {fileID: 412968735}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &413164446 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3281897250688815528, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+  m_PrefabInstance: {fileID: 288763502}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &413378523
 GameObject:
   m_ObjectHideFlags: 0
@@ -91558,6 +91563,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 474172900}
   m_CullTransparentMesh: 1
+--- !u!1 &475618833 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3281897250688815528, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+  m_PrefabInstance: {fileID: 1122383122}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &475957800
 GameObject:
   m_ObjectHideFlags: 0
@@ -121456,6 +121466,11 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &641821493 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3281897250688815528, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+  m_PrefabInstance: {fileID: 620226101}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &642159166 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8365709615824847231, guid: 6c68d4a1005822840ad87fa6b688cf51, type: 3}
@@ -130533,6 +130548,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 683734837}
   m_CullTransparentMesh: 1
+--- !u!1 &683852704 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6386769653165351644, guid: 9e03b35f186cacd4fa09c13eb2318589, type: 3}
+  m_PrefabInstance: {fileID: 646369421}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &683901300
 GameObject:
   m_ObjectHideFlags: 0
@@ -145814,9 +145834,17 @@ MonoBehaviour:
   servers: {fileID: 45511641}
   dataCenters: {fileID: 1581953281}
   planets: {fileID: 1299375796}
+  assemblyLinesProgressBarRoot: {fileID: 2016178899}
+  managersProgressBarRoot: {fileID: 1436132246}
+  serversProgressBarRoot: {fileID: 475618833}
+  dataCentersProgressBarRoot: {fileID: 413164446}
+  planetsProgressBarRoot: {fileID: 641821493}
   matrioshkaBrainsFill: {fileID: 929191127}
   birchPlanetsFill: {fileID: 1785389238}
   galacticBrainsFill: {fileID: 825908785}
+  matrioshkaBrainsProgressBarRoot: {fileID: 2096545771}
+  birchPlanetsProgressBarRoot: {fileID: 946312008}
+  galacticBrainsProgressBarRoot: {fileID: 683852704}
 --- !u!1 &782538228
 GameObject:
   m_ObjectHideFlags: 0
@@ -174043,6 +174071,11 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &946312008 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6386769653165351644, guid: 9e03b35f186cacd4fa09c13eb2318589, type: 3}
+  m_PrefabInstance: {fileID: 1839440834}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &946549682
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -259827,6 +259860,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1434999025}
   m_CullTransparentMesh: 1
+--- !u!1 &1436132246 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3281897250688815528, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+  m_PrefabInstance: {fileID: 530388803}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1436878107
 GameObject:
   m_ObjectHideFlags: 0
@@ -364222,6 +364260,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2015399611}
   m_CullTransparentMesh: 1
+--- !u!1 &2016178899 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3281897250688815528, guid: 247830d86bfc9714dbbf4a1ca0107011, type: 3}
+  m_PrefabInstance: {fileID: 7806472730904507485}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2016957700
 GameObject:
   m_ObjectHideFlags: 0
@@ -377983,6 +378026,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2096413269}
   m_CullTransparentMesh: 1
+--- !u!1 &2096545771 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6386769653165351644, guid: 9e03b35f186cacd4fa09c13eb2318589, type: 3}
+  m_PrefabInstance: {fileID: 1256389610}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2096581404
 GameObject:
   m_ObjectHideFlags: 0
@@ -389103,6 +389151,7 @@ MonoBehaviour:
     - Name: 
       Entry: 8
       Data: 
+  beta: 0
   recoveryButton: {fileID: 687595187}
   recoveryText: {fileID: 438082819}
   prestigeButton: {fileID: 2067238867}
@@ -389123,7 +389172,6 @@ MonoBehaviour:
   skillsHolder: {fileID: 1246707435}
   listOfSkillsNotToAutoBuy: 0b0000000c0000003b000000
   Loaded: 0
-  beta: 0
   bsGamesData:
     latestGameName: 
     latestGameLink: 

--- a/Assets/Scripts/Buildings/BotPanelManager.cs
+++ b/Assets/Scripts/Buildings/BotPanelManager.cs
@@ -2,6 +2,28 @@ using Blindsided.ProceduralUIImage;
 using UnityEngine;
 using static Expansion.Oracle;
 
+/// <summary>
+/// BotPanelManager
+/// Runtime: yes (scene UI).
+///
+/// Purpose:
+/// Controls visibility and progress bar presentation for the bot/facility panels (including mega-structures).
+/// Progress bars are driven by facility production rates and "in-progress" fractional counts stored in
+/// <see cref="DysonVerseInfinityData"/>.
+///
+/// Primary entry points:
+/// - <see cref="Update"/>: toggles panel visibility and updates progress bars each frame.
+///
+/// Interacts with:
+/// - Expansion.Oracle (oracle.saveSettings.dysonVerseSaveData.dysonVerseInfinityData et al)
+/// - <see cref="ProgressBarFlickerManager"/> (solid-vs-progressing bar rule)
+/// - Blindsided.ProceduralUIImage.ProceduralUIImage (fillAmount)
+///
+/// Change notes:
+/// - Serialized references (panels, images, progress bar roots) must be wired in the relevant prefab/scene.
+/// - If you change which production rate feeds a bar, also update the matching "toggle off when not producing"
+///   condition so bars don't appear dead.
+/// </summary>
 public class BotPanelManager : MonoBehaviour
 {
     [SerializeField] private GameObject clickPanel;
@@ -25,6 +47,18 @@ public class BotPanelManager : MonoBehaviour
     [SerializeField] private ProceduralUIImage dataCenters;
     [SerializeField] private ProceduralUIImage planets;
 
+    [Header("Progress Bar Roots (Optional)")]
+    [Tooltip("Optional root GameObject to toggle the Assembly Lines progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject assemblyLinesProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Managers progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject managersProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Servers progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject serversProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Data Centers progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject dataCentersProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Planets progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject planetsProgressBarRoot;
+
     [Header("Mega-Structure Fill Bars")]
     [Tooltip("Fill bar for Matrioshka Brains 'in-progress' production.")]
     [SerializeField] private ProceduralUIImage matrioshkaBrainsFill;
@@ -32,6 +66,14 @@ public class BotPanelManager : MonoBehaviour
     [SerializeField] private ProceduralUIImage birchPlanetsFill;
     [Tooltip("Fill bar for Galactic Brains (if you have a bar for it).")]
     [SerializeField] private ProceduralUIImage galacticBrainsFill;
+
+    [Header("Mega-Structure Progress Bar Roots (Optional)")]
+    [Tooltip("Optional root GameObject to toggle the Matrioshka Brains progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject matrioshkaBrainsProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Birch Planets progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject birchPlanetsProgressBarRoot;
+    [Tooltip("Optional root GameObject to toggle the Galactic Brains progress bar on/off when nothing is producing it.")]
+    [SerializeField] private GameObject galacticBrainsProgressBarRoot;
 
     private DysonVerseInfinityData infinityData => oracle.saveSettings.dysonVerseSaveData.dysonVerseInfinityData;
     private DysonVerseSkillTreeData skillTreeData => oracle.saveSettings.dysonVerseSaveData.dysonVerseSkillTreeData;
@@ -53,29 +95,81 @@ public class BotPanelManager : MonoBehaviour
         // Mega-structure visibility and questionmark panel
         UpdateMegaStructureVisibility(hasDataCenters);
 
-        assemblyLines.fillAmount = infinityData.assemblyLineProduction >= 5 ? 1 : (float)(infinityData.assemblyLines[0] % 1);
-        managers.fillAmount = infinityData.managerProduction >= 5 ? 1 : (float)(infinityData.managers[0] % 1);
-        servers.fillAmount =
-            infinityData.serverProduction + infinityData.rudimentrySingularityProduction >= 5 ? 1 : (float)(infinityData.servers[0] % 1);
-        dataCenters.fillAmount = infinityData.dataCenterProduction + infinityData.pocketDimensionsProduction >= 5
-            ? 1
-            : (float)(infinityData.dataCenters[0] % 1);
-        planets.fillAmount = infinityData.scientificPlanetsProduction + infinityData.stellarSacrificesProduction +
-            infinityData.planetAssemblyProduction + infinityData.shellWorldsProduction >= 5
-                ? 1
-                : (float)(infinityData.planets[0] % 1);
+        // Producer tiers
+        SetFacilityProgressBar(
+            assemblyLines,
+            assemblyLinesProgressBarRoot,
+            infinityData.assemblyLineProduction,
+            infinityData.assemblyLines[0]);
+
+        SetFacilityProgressBar(
+            managers,
+            managersProgressBarRoot,
+            infinityData.managerProduction,
+            infinityData.managers[0]);
+
+        SetFacilityProgressBar(
+            servers,
+            serversProgressBarRoot,
+            infinityData.serverProduction + infinityData.rudimentrySingularityProduction,
+            infinityData.servers[0]);
+
+        SetFacilityProgressBar(
+            dataCenters,
+            dataCentersProgressBarRoot,
+            infinityData.dataCenterProduction + infinityData.pocketDimensionsProduction,
+            infinityData.dataCenters[0]);
+
+        SetFacilityProgressBar(
+            planets,
+            planetsProgressBarRoot,
+            infinityData.scientificPlanetsProduction + infinityData.stellarSacrificesProduction +
+            infinityData.planetAssemblyProduction + infinityData.shellWorldsProduction,
+            infinityData.planets[0]);
 
         // Mega-structure progress (these are produced by the tier above them).
-        if (matrioshkaBrainsFill != null)
-            matrioshkaBrainsFill.fillAmount = infinityData.birchPlanetMatrioshkaProduction >= 5
-                ? 1
-                : (float)(infinityData.matrioshkaBrains[0] % 1);
-        if (birchPlanetsFill != null)
-            birchPlanetsFill.fillAmount = infinityData.galacticBrainBirchProduction >= 5
-                ? 1
-                : (float)(infinityData.birchPlanets[0] % 1);
-        if (galacticBrainsFill != null)
-            galacticBrainsFill.fillAmount = (float)(infinityData.galacticBrains[0] % 1);
+        SetFacilityProgressBar(
+            matrioshkaBrainsFill,
+            matrioshkaBrainsProgressBarRoot,
+            infinityData.birchPlanetMatrioshkaProduction,
+            infinityData.matrioshkaBrains[0]);
+
+        SetFacilityProgressBar(
+            birchPlanetsFill,
+            birchPlanetsProgressBarRoot,
+            infinityData.galacticBrainBirchProduction,
+            infinityData.birchPlanets[0]);
+
+        // Galactic Brains are currently the top tier; there is no "producer" above them in the production system.
+        // If/when a production rate exists, pass it here to enable auto-toggle and solid-fill behavior.
+        SetFacilityProgressBar(
+            galacticBrainsFill,
+            galacticBrainsProgressBarRoot,
+            0,
+            infinityData.galacticBrains[0]);
+    }
+
+    private static void SetFacilityProgressBar(
+        ProceduralUIImage fillImage,
+        GameObject progressBarRoot,
+        double productionPerSecond,
+        double runningCountWithFraction)
+    {
+        if (fillImage == null)
+            return;
+
+        bool hasProduction = productionPerSecond > 0;
+        if (progressBarRoot != null)
+            progressBarRoot.SetActive(hasProduction);
+
+        if (!hasProduction)
+        {
+            // Avoid leaving stale fill visible if the root isn't wired or is shared.
+            fillImage.fillAmount = 0;
+            return;
+        }
+
+        fillImage.fillAmount = ProgressBarFlickerManager.ComputeFillAmount(productionPerSecond, runningCountWithFraction);
     }
 
     private void UpdateMegaStructureVisibility(bool hasDataCenters)

--- a/Assets/Scripts/Classes/ProgressBarFlickerManager.cs
+++ b/Assets/Scripts/Classes/ProgressBarFlickerManager.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+
+/// <summary>
+/// ProgressBarFlickerManager
+/// Runtime: yes (static utility).
+///
+/// Purpose:
+/// Centralizes the rule for whether a progress bar should appear "solid" (full)
+/// versus "progressing" (showing fractional fill).
+///
+/// Primary entry points:
+/// - <see cref="SolidFillThresholdPerSecond"/>: global threshold in "completions per second".
+/// - <see cref="ShouldRenderSolid(double)"/>
+/// - <see cref="ComputeFillAmount(double, double)"/>
+///
+/// Interacts with:
+/// - UnityEngine.PlayerPrefs (persists threshold for balancing/config).
+///
+/// Change notes:
+/// - Changing <see cref="SolidFillThresholdPerSecondPrefKey"/> breaks existing saved preferences.
+/// - The semantic meaning of "completions per second" must match the values passed by callers
+///   (typically facility production rates).
+/// </summary>
+public static class ProgressBarFlickerManager
+{
+    // Intentionally explicit and stable: used in PlayerPrefs across versions.
+    public const string SolidFillThresholdPerSecondPrefKey = "progress_bars.solid_threshold_per_second";
+
+    // Default used when PlayerPrefs doesn't have a value yet.
+    public const float DefaultSolidFillThresholdPerSecond = 4f;
+
+    /// <summary>
+    /// Global threshold (in completions per second) at or above which progress bars should be rendered solid.
+    /// Stored in PlayerPrefs for easy balancing.
+    /// </summary>
+    public static float SolidFillThresholdPerSecond
+    {
+        get => PlayerPrefs.GetFloat(SolidFillThresholdPerSecondPrefKey, DefaultSolidFillThresholdPerSecond);
+        set => PlayerPrefs.SetFloat(SolidFillThresholdPerSecondPrefKey, Mathf.Max(0f, value));
+    }
+
+    public static bool ShouldRenderSolid(double completionsPerSecond)
+    {
+        if (double.IsNaN(completionsPerSecond) || double.IsInfinity(completionsPerSecond))
+            return false;
+
+        return completionsPerSecond >= SolidFillThresholdPerSecond;
+    }
+
+    /// <summary>
+    /// Returns the UI fill amount in [0..1] for a progress bar where progress is represented as a running
+    /// "count" that includes a fractional part (e.g., facilityArray[0] in DysonVerseInfinityData).
+    /// </summary>
+    public static float ComputeFillAmount(double completionsPerSecond, double runningCountWithFraction)
+    {
+        if (ShouldRenderSolid(completionsPerSecond))
+            return 1f;
+
+        if (double.IsNaN(runningCountWithFraction) || double.IsInfinity(runningCountWithFraction))
+            return 0f;
+
+        double frac = runningCountWithFraction % 1.0;
+        if (frac < 0)
+            frac += 1.0;
+
+        return Mathf.Clamp01((float)frac);
+    }
+}

--- a/Assets/Scripts/Classes/ProgressBarFlickerManager.cs.meta
+++ b/Assets/Scripts/Classes/ProgressBarFlickerManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 430cdeaeb843c461d819f0b87e1812ff

--- a/Documentation/Code/ProgressBarFlickerManager.md
+++ b/Documentation/Code/ProgressBarFlickerManager.md
@@ -1,0 +1,38 @@
+# ProgressBarFlickerManager
+
+## Purpose
+Central place to decide how production progress bars should be visually represented:
+- **Solid** (full fill) when completions are frequent enough that a moving bar would just flicker.
+- **Progressing** (fractional fill) when completions are infrequent enough that seeing progression is useful.
+
+This is intended to be shared by many UI scripts over time (BotPanelManager is the first adopter).
+
+## Inputs/Outputs
+- Input: `completionsPerSecond` (double)
+  - Should match the production-rate values used by the simulation (e.g., facility `ProductionRate`).
+- Input: `runningCountWithFraction` (double)
+  - A monotonically increasing count that carries fractional progress in its `x % 1` portion.
+- Output: `fillAmount` (float, clamped to `[0..1]`)
+
+## Configuration (global)
+PlayerPrefs:
+- Key: `progress_bars.solid_threshold_per_second`
+- Meaning: if `completionsPerSecond >= threshold`, bar renders solid (`fillAmount = 1`).
+- Default: `4.0`.
+
+API:
+- `ProgressBarFlickerManager.SolidFillThresholdPerSecond`
+  - Reads/writes PlayerPrefs.
+
+## Current Call Sites
+- `/Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Buildings/BotPanelManager.cs`
+  - Uses it for assembly lines, managers, servers, data centers, planets, and mega-structure bars.
+
+## Save/Load Implications
+- Renaming `SolidFillThresholdPerSecondPrefKey` will orphan existing player configurations.
+
+## Verification
+1. In a scene/prefab where `BotPanelManager` is present, wire the new `*ProgressBarRoot` fields to the bar root GameObjects.
+2. Ensure a facility has **0** production: its bar root should disable (no dead bar visible).
+3. Ensure a facility has low production (< threshold): bar should show fractional progression.
+4. Ensure a facility has high production (>= threshold): bar should stay solid (full).

--- a/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
+++ b/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
@@ -24,7 +24,7 @@ MonoBehaviour:
   m_MinSize: {x: 500, y: 112}
   m_MaxSize: {x: 40480, y: 16192}
   vertical: 0
-  controlID: 16561
+  controlID: 24925
   draggingID: 0
 --- !u!114 &2
 MonoBehaviour:
@@ -47,7 +47,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Game\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 2734.5
+    x: 2735.5
     y: 95
     width: 1103.5
     height: 508
@@ -155,7 +155,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 56}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 16557
+  controlID: 24645
   draggingID: 0
 --- !u!114 &4
 MonoBehaviour:
@@ -204,7 +204,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Hierarchy\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 56
+    x: 57
     y: 95
     width: 480
     height: 940
@@ -223,16 +223,93 @@ MonoBehaviour:
     m_DynamicPanelBehavior: 0
   m_SceneHierarchy:
     m_TreeViewState:
-      scrollPos: {x: 0, y: 159}
+      scrollPos: {x: 0, y: 0}
       m_SelectedIDs:
-      - m_Data: 52644
+      - m_Data: 55866
       m_LastClickedID:
-        m_Data: 52644
+        m_Data: 55866
       m_ExpandedIDs:
+      - m_Data: -187478
+      - m_Data: -187468
+      - m_Data: -187458
+      - m_Data: -187408
+      - m_Data: -187398
       - m_Data: -140112
+      - m_Data: -25220
+      - m_Data: -25206
+      - m_Data: -25172
+      - m_Data: -25164
+      - m_Data: -25148
+      - m_Data: -22332
+      - m_Data: -22320
+      - m_Data: -22314
+      - m_Data: -22308
+      - m_Data: -22298
+      - m_Data: -22292
+      - m_Data: -22278
+      - m_Data: -22258
+      - m_Data: -22252
+      - m_Data: -22244
+      - m_Data: -22236
+      - m_Data: -22220
+      - m_Data: -17296
+      - m_Data: -17286
+      - m_Data: -17278
+      - m_Data: -17270
+      - m_Data: -17258
+      - m_Data: -17252
+      - m_Data: -17238
+      - m_Data: -17216
+      - m_Data: -17208
+      - m_Data: -17200
+      - m_Data: -17192
+      - m_Data: -17176
+      - m_Data: -17040
+      - m_Data: -17032
+      - m_Data: -17016
       - m_Data: -16882
       - m_Data: -16874
       - m_Data: -16858
+      - m_Data: -16674
+      - m_Data: -16662
+      - m_Data: -16656
+      - m_Data: -16650
+      - m_Data: -16640
+      - m_Data: -16634
+      - m_Data: -16620
+      - m_Data: -16600
+      - m_Data: -16594
+      - m_Data: -16586
+      - m_Data: -16578
+      - m_Data: -16562
+      - m_Data: -14198
+      - m_Data: -14188
+      - m_Data: -14176
+      - m_Data: -14136
+      - m_Data: -9822
+      - m_Data: -9812
+      - m_Data: -9804
+      - m_Data: -9796
+      - m_Data: -9784
+      - m_Data: -9778
+      - m_Data: -9764
+      - m_Data: -9742
+      - m_Data: -9734
+      - m_Data: -9726
+      - m_Data: -9718
+      - m_Data: -9702
+      - m_Data: -7362
+      - m_Data: -7352
+      - m_Data: -7344
+      - m_Data: -7336
+      - m_Data: -7324
+      - m_Data: -7318
+      - m_Data: -7304
+      - m_Data: -7282
+      - m_Data: -7274
+      - m_Data: -7266
+      - m_Data: -7258
+      - m_Data: -7242
       - m_Data: -1326
       - m_Data: -12
       - m_Data: 46344
@@ -251,13 +328,13 @@ MonoBehaviour:
       - m_Data: 58018
       - m_Data: 58846
       - m_Data: 59446
+      - m_Data: 59534
       - m_Data: 60670
       - m_Data: 60820
       - m_Data: 60850
       - m_Data: 62118
       - m_Data: 63566
       - m_Data: 67084
-      - m_Data: 67162
       - m_Data: 67538
       - m_Data: 68692
       - m_Data: 71740
@@ -335,7 +412,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Inspector\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 537
+    x: 538
     y: 95
     width: 503
     height: 940
@@ -359,7 +436,7 @@ MonoBehaviour:
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
   m_LastInspectedObjectInstanceID: -1
-  m_LastVerticalScrollValue: 0
+  m_LastVerticalScrollValue: 47
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:
@@ -389,7 +466,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 112}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 16562
+  controlID: 24926
   draggingID: 0
 --- !u!114 &9
 MonoBehaviour:
@@ -438,7 +515,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Scene\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1042
+    x: 1043
     y: 95
     width: 1690.5
     height: 940
@@ -1054,9 +1131,9 @@ MonoBehaviour:
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: 1409.7178, y: 781.45294, z: -2.6917384}
+    m_Target: {x: 646.3057, y: 637.1148, z: -4.0475683}
     speed: 2
-    m_Value: {x: 1409.7178, y: 781.45294, z: -2.6917384}
+    m_Value: {x: 646.3057, y: 637.1148, z: -4.0475683}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -1106,9 +1183,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 279.1846
+    m_Target: 414.7676
     speed: 2
-    m_Value: 279.1846
+    m_Value: 414.7676
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -1166,7 +1243,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 112}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 16572
+  controlID: 24995
   draggingID: 0
 --- !u!114 &12
 MonoBehaviour:
@@ -1218,7 +1295,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 56}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 16597
+  controlID: 25051
   draggingID: 0
 --- !u!114 &14
 MonoBehaviour:
@@ -1267,7 +1344,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Console\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 2734.5
+    x: 2735.5
     y: 629
     width: 592
     height: 406
@@ -1331,7 +1408,7 @@ MonoBehaviour:
     m_TextWithWhitespace: "Project\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 3328.5
+    x: 3329.5
     y: 629
     width: 509.5
     height: 406
@@ -1359,7 +1436,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Scripts/Buildings
+    - Assets/Prefabs/Buildings
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1369,18 +1446,18 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 56
   m_LastFolders:
-  - Assets/Scripts/Buildings
+  - Assets/Prefabs/Buildings
   m_LastFoldersGridSize: 56
   m_LastProjectPath: /Users/matthewrushworth/Projects/Idle Dyson Swarm
   m_LockTracker:
     m_IsLocked: 0
   m_LastLocalAssetsSearchArea: 1
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 562}
+    scrollPos: {x: 0, y: 543}
     m_SelectedIDs:
-    - m_Data: 117658
+    - m_Data: 486428
     m_LastClickedID:
-      m_Data: 117658
+      m_Data: 486428
     m_ExpandedIDs:
     - m_Data: 0
     - m_Data: 90970
@@ -1388,6 +1465,7 @@ MonoBehaviour:
     - m_Data: 90974
     - m_Data: 90976
     - m_Data: 90978
+    - m_Data: 91142
     - m_Data: 91150
     - m_Data: 1000000000
     m_RenameOverlay:
@@ -1455,8 +1533,8 @@ MonoBehaviour:
       m_ResourceFile: 
   m_ListAreaState:
     m_SelectedInstanceIDs:
-    - m_Data: 52644
-    m_LastClickedInstanceID: 52644
+    - m_Data: 55866
+    m_LastClickedInstanceID: 55866
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: []
     m_RenameOverlay:


### PR DESCRIPTION
**Summary**
- add progress bar roots to `BotPanelManager` so production-driven bars can be toggled off when the facility is idle
- refactor BotPanelManager to route fill logic through a new `ProgressBarFlickerManager` helper that centralizes the solid/progress behavior
- document the new helper and persistence key in `Documentation/Code/ProgressBarFlickerManager.md`

**Testing**
- Not run (not requested)