### PR TITLE
fix(ui): keep preset automation toggle selected on click

### DIFF
--- a/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
+++ b/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
@@ -34,6 +34,8 @@ using static Expansion.Oracle;
 /// - Preset automation preferences persist in <c>Oracle.SaveDataSettings</c> (export/import with save).
 /// - Preset switching touches live auto-assign state; keep <c>oracle.SuppressPresetSync()</c> usage intact when
 ///   changing switch behavior.
+/// - Toggle binding loops must not capture the loop index variable inside closures; always capture a per-iteration
+///   index value to avoid incorrect UI state (for example all toggles being forced off).
 /// </remarks>
 public class SkillTreeSettingsManager : MonoBehaviour
 {
@@ -830,10 +832,11 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
         for (int i = 0; i < toggles.Length; i++)
         {
-            Toggle toggle = toggles[i];
+            int toggleIndex = i; // capture per-iteration index for the closure
+            Toggle toggle = toggles[toggleIndex];
             if (toggle == null) continue;
 
-            int overrideValue = i < 5 ? i + 1 : 0; // last toggle is Off
+            int overrideValue = toggleIndex < 5 ? toggleIndex + 1 : 0; // last toggle is Off
             UnityAction<bool> handler = isOn =>
             {
                 if (_suppressToggleCallbacks) return;
@@ -854,7 +857,7 @@ public class SkillTreeSettingsManager : MonoBehaviour
                 for (int j = 0; j < toggles.Length; j++)
                 {
                     if (toggles[j] == null) continue;
-                    toggles[j].isOn = j == i;
+                    toggles[j].isOn = j == toggleIndex;
                 }
                 _suppressToggleCallbacks = false;
 

--- a/Documentation/Code/SkillTreeSettingsManager.md
+++ b/Documentation/Code/SkillTreeSettingsManager.md
@@ -32,6 +32,9 @@
 - Tab preset automation toggles:
   - Selecting a slot only updates the override preference (no immediate preset switching).
   - The selected toggle hides its label text to reveal the icon (including Off).
+  - Implementation detail: automation toggle callbacks must capture a per-iteration index value (do not reference the
+    `for` loop variable directly inside the closure) or the handler can end up forcing all toggles off, which makes
+    the checkmark graphic appear "broken" even though labels update.
 - Tab open detection:
   - Uses `SidePanelReferences.botsTabButton` / `SidePanelReferences.researchTabButton` (wired on both overlay and permanent refs).
   - Also supports optional bottom-bar (or other) navigation buttons wired directly on `SkillTreeSettingsManager`:
@@ -59,5 +62,6 @@
 3. Toggle UX:
   - Selecting any automation toggle hides its label, showing the icon.
   - Preset 1-5 labels show short labels derived from preset names.
+  - Clicking automation toggles immediately shows the checkmark on the selected toggle (no need to tab-swap).
 4. Save persistence:
   - Export/import save retains `botsTabPresetOverride` and `researchTabPresetOverride`.


### PR DESCRIPTION
### What
- Fix preset-automation (Bots/Research settings) toggles clearing their own selection immediately after click (checkmark would disappear until tab swap).

### Why
- The automation toggle callbacks captured the for-loop index, so every handler used the final index and forced all toggles off.

### How
- Capture a per-iteration toggle index for the closure and use it when enforcing single-selection.
- Document the closure pitfall + verification note in SkillTreeSettingsManager docs.

### Testing
- Not run (Unity/manual).