### PR TITLE
refactor(buy): extract BuyMode switch into BuyModeHelper

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/BuyModeHelper.cs
+++ b/Assets/Scripts/Blindsided/Utilities/BuyModeHelper.cs
@@ -1,0 +1,32 @@
+using static Expansion.Oracle;
+
+namespace Blindsided.Utilities
+{
+    /// <summary>
+    /// Centralized BuyMode quantity calculation. Replaces duplicated switch logic
+    /// across Building, BuildingsOverlord, MegaStructurePresenter, and ResearchPresenter.
+    /// </summary>
+    public static class BuyModeHelper
+    {
+        /// <summary>
+        /// Calculates the number of items to buy based on the current buy mode.
+        /// </summary>
+        /// <param name="mode">The active buy mode.</param>
+        /// <param name="roundedBulkBuy">Whether to round to the next multiple.</param>
+        /// <param name="currentOwned">Current count of the item (for rounding).</param>
+        /// <param name="maxAffordable">Max items the player can afford (for BuyMax).</param>
+        /// <returns>The number of items to buy.</returns>
+        public static long GetAmountToBuy(BuyMode mode, bool roundedBulkBuy, long currentOwned, long maxAffordable)
+        {
+            return mode switch
+            {
+                BuyMode.Buy1 => 1,
+                BuyMode.Buy10 => roundedBulkBuy ? 10 - currentOwned % 10 : 10,
+                BuyMode.Buy50 => roundedBulkBuy ? 50 - currentOwned % 50 : 50,
+                BuyMode.Buy100 => roundedBulkBuy ? 100 - currentOwned % 100 : 100,
+                BuyMode.BuyMax => maxAffordable > 0 ? maxAffordable : 1,
+                _ => 1
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Buildings/Building.cs
+++ b/Assets/Scripts/Buildings/Building.cs
@@ -102,32 +102,9 @@ namespace Buildings
 
         public long NumberToBuy()
         {
-            long number = 0;
-            switch (StaticBuyMode)
-            {
-                case BuyMode.Buy1:
-                    number = 1;
-                    break;
-                case BuyMode.Buy10:
-                {
-                    number = StaticRoundedBulkBuy ? 10 - (int)ManuallyPurchasedBuildings % 10 : 10;
-                }
-                    break;
-                case BuyMode.Buy50:
-                {
-                    number = StaticRoundedBulkBuy ? 50 - (int)ManuallyPurchasedBuildings % 50 : 50;
-                }
-                    break;
-                case BuyMode.Buy100:
-                {
-                    number = StaticRoundedBulkBuy ? 100 - (int)ManuallyPurchasedBuildings % 100 : 100;
-                }
-                    break;
-                case BuyMode.BuyMax:
-                    number = Affordable() > 0 ? Affordable() : 1;
-                    break;
-            }
-            return number;
+            return BuyModeHelper.GetAmountToBuy(
+                StaticBuyMode, StaticRoundedBulkBuy,
+                (long)ManuallyPurchasedBuildings, Affordable());
         }
 
         public void UpdateCostText()

--- a/Assets/Scripts/Buildings/BuildingsOverlord.cs
+++ b/Assets/Scripts/Buildings/BuildingsOverlord.cs
@@ -1,3 +1,4 @@
+using Blindsided.Utilities;
 using UnityEngine;
 using static Expansion.Oracle;
 
@@ -49,38 +50,8 @@ public class BuildingsOverlord : MonoBehaviour
 
     public long AmountToBuy(long currentAmount, long maxAffordable)
     {
-        long amountToReturn = 0;
-        switch (oracle.saveSettings.buyMode)
-        {
-            case BuyMode.Buy1:
-                amountToReturn = 1;
-                break;
-            case BuyMode.Buy10:
-            {
-                if (oracle.saveSettings.roundedBulkBuy)
-                    amountToReturn = 10 - currentAmount % 10;
-                else amountToReturn = 10;
-            }
-                break;
-            case BuyMode.Buy50:
-            {
-                if (oracle.saveSettings.roundedBulkBuy)
-                    amountToReturn = 50 - currentAmount % 50;
-                else amountToReturn = 50;
-            }
-                break;
-            case BuyMode.Buy100:
-            {
-                if (oracle.saveSettings.roundedBulkBuy)
-                    amountToReturn = 100 - currentAmount % 100;
-                else amountToReturn = 100;
-            }
-                break;
-            case BuyMode.BuyMax:
-                amountToReturn = maxAffordable;
-                break;
-        }
-
-        return amountToReturn;
+        return BuyModeHelper.GetAmountToBuy(
+            oracle.saveSettings.buyMode, oracle.saveSettings.roundedBulkBuy,
+            currentAmount, maxAffordable);
     }
 }

--- a/Assets/Scripts/Buildings/MegaStructurePresenter.cs
+++ b/Assets/Scripts/Buildings/MegaStructurePresenter.cs
@@ -349,22 +349,9 @@ namespace Buildings
         private int NumberToBuy()
         {
             int maxAffordable = _megaStructureService.MaxAffordable(FacilityId);
-
-            return StaticBuyMode switch
-            {
-                BuyMode.Buy1 => 1,
-                BuyMode.Buy10 => StaticRoundedBulkBuy
-                    ? 10 - (int)ManuallyPurchased % 10
-                    : 10,
-                BuyMode.Buy50 => StaticRoundedBulkBuy
-                    ? 50 - (int)ManuallyPurchased % 50
-                    : 50,
-                BuyMode.Buy100 => StaticRoundedBulkBuy
-                    ? 100 - (int)ManuallyPurchased % 100
-                    : 100,
-                BuyMode.BuyMax => maxAffordable > 0 ? maxAffordable : 1,
-                _ => 1
-            };
+            return (int)BuyModeHelper.GetAmountToBuy(
+                StaticBuyMode, StaticRoundedBulkBuy,
+                (long)ManuallyPurchased, maxAffordable);
         }
 
         #endregion

--- a/Assets/Scripts/Research/ResearchPresenter.cs
+++ b/Assets/Scripts/Research/ResearchPresenter.cs
@@ -1,4 +1,5 @@
 using System;
+using Blindsided.Utilities;
 using Buildings;
 using Expansion;
 using GameData;
@@ -310,28 +311,10 @@ namespace Research
         {
             if (IsMaxed) return 0;
 
-            long number = 0;
-            bool roundedBulkBuy = _gameState.RoundedBulkBuy;
-            switch (_gameState.ResearchBuyMode)
-            {
-                case Oracle.BuyMode.Buy1:
-                    number = 1;
-                    break;
-                case Oracle.BuyMode.Buy10:
-                    number = roundedBulkBuy ? 10 - (int)CurrentLevel % 10 : 10;
-                    break;
-                case Oracle.BuyMode.Buy50:
-                    number = roundedBulkBuy ? 50 - (int)CurrentLevel % 50 : 50;
-                    break;
-                case Oracle.BuyMode.Buy100:
-                    number = roundedBulkBuy ? 100 - (int)CurrentLevel % 100 : 100;
-                    break;
-                case Oracle.BuyMode.BuyMax:
-                    number = Affordable() > 0 ? Affordable() : 1;
-                    break;
-            }
-
-            return ClampToRemaining(number);
+            long amount = BuyModeHelper.GetAmountToBuy(
+                _gameState.ResearchBuyMode, _gameState.RoundedBulkBuy,
+                (long)CurrentLevel, Affordable());
+            return ClampToRemaining(amount);
         }
 
         private double ClampLevel(double level)


### PR DESCRIPTION
## Summary
- Extract duplicated BuyMode quantity switch logic from 4 files into a single `BuyModeHelper.GetAmountToBuy()` static method in `Blindsided.Utilities`
- Replaces ~100 lines of copy-pasted switch blocks with one-liner calls to the shared helper
- Files updated: `Building.cs`, `BuildingsOverlord.cs`, `MegaStructurePresenter.cs`, `ResearchPresenter.cs`
- Intentionally leaves `BuyXSettings`/`ResearchBuyXSettings` (trivial UI wiring) and `BuildingsOverlord.CalculateCosts()` (different concern) unchanged

## Test plan
- [ ] Verify compilation in Unity Editor
- [ ] Purchase buildings in Buy1, Buy10, Buy50, Buy100, BuyMax modes
- [ ] Toggle rounded bulk buy and verify rounding behavior
- [ ] Purchase research in all buy modes
- [ ] Purchase mega-structures in all buy modes