### PR TITLE
feat(skill-tree): add not-purchasable color state in description mode

### DIFF
--- a/Assets/Scripts/SkillTreeStuff/SkillTreeManager.cs
+++ b/Assets/Scripts/SkillTreeStuff/SkillTreeManager.cs
@@ -10,6 +10,35 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using static Expansion.Oracle;
 
+/*
+Purpose:
+- Owns one skill node's runtime behavior in the skill tree: presentation, availability checks, click handling,
+  purchase/unassign, and line generation.
+
+Where it runs:
+- Runtime on each skill node GameObject in the skill tree UI.
+
+Primary entry points:
+- Unity lifecycle: OnEnable, Start, OnDisable.
+- UI input: Clicked, RightClicked, OnPointerClick.
+- Refresh path: UpdateSkill (from local and global update events).
+- Mutations: PurchaseSkill, ResetSkills.
+
+Interacts with:
+- Calls into: Expansion.Oracle (save data, ownership reads/writes, events, auto-assign APIs), GameDataRegistry/
+  SkillDatabase/SkillDefinition (skill metadata), SkillTreeConfirmationManager (description/confirm modal),
+  UIThemeProvider/UITheme (color sets), GameManager and DebugOptions update events.
+- Called by: Unity UI Button events, Unity lifecycle, Oracle/GameManager/DebugOptions skill update events,
+  and other systems that invoke SkillTreeManager.UpdateSkills.
+
+Change notes:
+- Serialized references (skillButton, purchasedImage, texts, ids/keys) are scene/prefab wired; renames require
+  updating Unity references.
+- Skill availability logic must stay aligned across UpdateSkill, ShowConfirmation, and PurchaseSkill; changing one
+  without the others can allow visual state and purchase rules to diverge.
+- skillKey/SkillId/SkillDefinition mapping relies on SkillIdMap + SkillDatabase + Oracle skill flags; ID changes
+  must be coordinated with save data migration and any ScriptableObject ID updates.
+*/
 [SelectionBase]
 public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
 {
@@ -41,28 +70,32 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
     {
         normal = new Color(0.32941177f, 0.63529414f, 0.67058825f),
         pressed = new Color(0.2576f, 0.4390621f, 0.46f),
-        disabled = new Color(0.21350001f, 0.33587933f, 0.35f)
+        disabled = new Color(0.21350001f, 0.33587933f, 0.35f),
+        notPurchasableNormal = new Color(0.21350001f, 0.33587933f, 0.35f)
     };
 
     private static readonly UITheme.SkillTreeButtonColors FallbackFragmentColors = new UITheme.SkillTreeButtonColors
     {
         normal = new Color(0.67058825f, 0.32941177f, 0.49019608f),
         pressed = new Color(0.46f, 0.2576f, 0.35298392f),
-        disabled = new Color(0.35f, 0.21350001f, 0.2778276f)
+        disabled = new Color(0.35f, 0.21350001f, 0.2778276f),
+        notPurchasableNormal = new Color(0.35f, 0.21350001f, 0.2778276f)
     };
 
     private static readonly UITheme.SkillTreeButtonColors FallbackNormalColors = new UITheme.SkillTreeButtonColors
     {
         normal = new Color(0.5019608f, 0.32941177f, 0.67058825f),
         pressed = new Color(0.35686275f, 0.25490198f, 0.45882353f),
-        disabled = new Color(0.2784314f, 0.21176471f, 0.34509805f)
+        disabled = new Color(0.2784314f, 0.21176471f, 0.34509805f),
+        notPurchasableNormal = new Color(0.2784314f, 0.21176471f, 0.34509805f)
     };
 
     private static readonly UITheme.SkillTreeButtonColors FallbackExclusiveLockColors = new UITheme.SkillTreeButtonColors
     {
         normal = new Color(0.4f, 0.4f, 0.4f),
         pressed = new Color(0.29803923f, 0.29803923f, 0.29803923f),
-        disabled = new Color(0.2f, 0.2f, 0.2f)
+        disabled = new Color(0.2f, 0.2f, 0.2f),
+        notPurchasableNormal = new Color(0.2f, 0.2f, 0.2f)
     };
 
     public static event Action UpdateSkills;
@@ -541,6 +574,14 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
         string[] requiredIds = GetRequiredSkillIds();
         string[] shadowIds = GetShadowRequirementIds();
         string[] exclusiveIds = GetExclusiveWithIds();
+        bool exclusiveOwned = HasExclusiveOwned(exclusiveIds);
+        bool canPurchaseNow = !owned
+                              && AreRequirementsMet(requiredIds)
+                              && AreRequirementsMet(shadowIds)
+                              && skillTreeData.skillPointsTree >= cost
+                              && !exclusiveOwned;
+        SkillTreeColorType colorType = ResolveCurrentColorType(exclusiveOwned);
+        bool useNotPurchasableVisual = !oracle.saveSettings.skillsBuyOnTap && !owned && !canPurchaseNow;
 
         if (oracle.saveSettings.skillsBuyOnTap)
         {
@@ -555,51 +596,52 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
                 if (!AreRequirementsMet(shadowIds)) available = false;
                 if (skillTreeData.skillPointsTree < cost) available = false;
             }
-
-            if (exclusiveIds is { Length: >= 1 })
-            {
-                if (HasExclusiveOwned(exclusiveIds))
-                {
-                    available = false;
-                    ApplySkillButtonColors(SkillTreeColorType.ExclusiveLock);
-                }
-                else
-                {
-                    ApplySkillButtonColors(SkillTreeColorType.Normal);
-                }
-            }
+            if (exclusiveOwned) available = false;
         }
         else
         {
             if (owned) purchasedImage.SetActive(true);
-            if (exclusiveIds is { Length: >= 1 })
-            {
-                if (HasExclusiveOwned(exclusiveIds))
-                {
-                    ApplySkillButtonColors(SkillTreeColorType.ExclusiveLock);
-                }
-                else
-                {
-                    ApplySkillButtonColors(SkillTreeColorType.Normal);
-                }
-            }
         }
 
-        skillButton.interactable = available;
+        ApplySkillButtonColors(colorType, useNotPurchasableVisual);
+        skillButton.interactable = oracle.saveSettings.skillsBuyOnTap ? available : true;
         ApplySkills?.Invoke();
     }
 
-    private void ApplySkillButtonColors(SkillTreeColorType colorType)
+    private SkillTreeColorType ResolveCurrentColorType(bool exclusiveOwned)
+    {
+        if (exclusiveOwned) return SkillTreeColorType.ExclusiveLock;
+        if (GetIsFragment()) return SkillTreeColorType.Fragment;
+        string[] requiredIds = GetRequiredSkillIds();
+        if (requiredIds == null || requiredIds.Length == 0) return SkillTreeColorType.NoRequired;
+        return SkillTreeColorType.Normal;
+    }
+
+    private void ApplySkillButtonColors(SkillTreeColorType colorType, bool useNotPurchasableNormal = false)
     {
         if (skillButton == null) return;
         UITheme.SkillTreeButtonColors colors = ResolveSkillTreeColors(colorType);
+        Color normalColor = colors.normal;
+        if (useNotPurchasableNormal)
+        {
+            normalColor = ResolveNotPurchasableNormalColor(colors);
+        }
+
         ColorBlock colourBlock = skillButton.colors;
-        colourBlock.normalColor = colors.normal;
-        colourBlock.highlightedColor = colors.normal;
+        colourBlock.normalColor = normalColor;
+        colourBlock.highlightedColor = normalColor;
         colourBlock.pressedColor = colors.pressed;
-        colourBlock.selectedColor = colors.normal;
+        colourBlock.selectedColor = normalColor;
         colourBlock.disabledColor = colors.disabled;
         skillButton.colors = colourBlock;
+    }
+
+    private static Color ResolveNotPurchasableNormalColor(UITheme.SkillTreeButtonColors colors)
+    {
+        Color fallback = Color.Lerp(colors.normal, Color.black, 0.35f);
+        fallback.a = colors.normal.a;
+        if (colors.notPurchasableNormal.a <= 0f) return fallback;
+        return colors.notPurchasableNormal;
     }
 
     private UITheme.SkillTreeButtonColors ResolveSkillTreeColors(SkillTreeColorType colorType)
@@ -870,4 +912,3 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
         linesMade = true;
     }
 }
-

--- a/Assets/Scripts/UI/Theme/UITheme.cs
+++ b/Assets/Scripts/UI/Theme/UITheme.cs
@@ -2,10 +2,31 @@ using UnityEngine;
 
 namespace IdleDysonSwarm.UI
 {
-    /// <summary>
-    /// ScriptableObject that defines the color palette and text formatting for the UI.
-    /// Create assets via Assets > Create > Idle Dyson Swarm > UI Theme.
-    /// </summary>
+    /*
+    Purpose:
+    - Central ScriptableObject theme definition for UI colors and rich-text color tags, including skill-tree button
+      state palettes.
+
+    Where it runs:
+    - Runtime + editor data asset; read by runtime UI systems and edited through Unity inspector.
+
+    Primary entry points:
+    - Field values are consumed by UI systems directly.
+    - Cached tag getters (AccentTag, HighlightTag, etc.) are read by UI formatting code.
+    - OnValidate clears cached tags when edited in the inspector.
+
+    Interacts with:
+    - Calls into: UnityEngine.ColorUtility (HTML color tag generation).
+    - Called by: UIThemeProvider and any UI/runtime script using theme colors, including SkillTreeManager button
+      coloring paths.
+
+    Change notes:
+    - Serialized field names are asset schema; renames require migration of existing UITheme assets.
+    - SkillTreeButtonColors additions/changes must remain compatible with existing theme assets loaded from
+      Resources/DefaultUITheme.asset.
+    - If defaults change here, verify both fallback behavior and any authored UITheme assets so visuals remain
+      intentional.
+    */
     [CreateAssetMenu(fileName = "UITheme", menuName = "Idle Dyson Swarm/UI Theme")]
     public class UITheme : ScriptableObject
     {
@@ -15,6 +36,8 @@ namespace IdleDysonSwarm.UI
             public Color normal;
             public Color pressed;
             public Color disabled;
+            [Tooltip("Used in description mode when a skill cannot currently be purchased but should remain clickable.")]
+            public Color notPurchasableNormal;
         }
 
         [Header("Text Colors")]
@@ -74,28 +97,32 @@ namespace IdleDysonSwarm.UI
         {
             normal = new Color(0.32941177f, 0.63529414f, 0.67058825f),
             pressed = new Color(0.2576f, 0.4390621f, 0.46f),
-            disabled = new Color(0.21350001f, 0.33587933f, 0.35f)
+            disabled = new Color(0.21350001f, 0.33587933f, 0.35f),
+            notPurchasableNormal = new Color(0.21350001f, 0.33587933f, 0.35f)
         };
 
         public SkillTreeButtonColors skillTreeFragment = new SkillTreeButtonColors
         {
             normal = new Color(0.67058825f, 0.32941177f, 0.49019608f),
             pressed = new Color(0.46f, 0.2576f, 0.35298392f),
-            disabled = new Color(0.35f, 0.21350001f, 0.2778276f)
+            disabled = new Color(0.35f, 0.21350001f, 0.2778276f),
+            notPurchasableNormal = new Color(0.35f, 0.21350001f, 0.2778276f)
         };
 
         public SkillTreeButtonColors skillTreeNormal = new SkillTreeButtonColors
         {
             normal = new Color(0.5019608f, 0.32941177f, 0.67058825f),
             pressed = new Color(0.35686275f, 0.25490198f, 0.45882353f),
-            disabled = new Color(0.2784314f, 0.21176471f, 0.34509805f)
+            disabled = new Color(0.2784314f, 0.21176471f, 0.34509805f),
+            notPurchasableNormal = new Color(0.2784314f, 0.21176471f, 0.34509805f)
         };
 
         public SkillTreeButtonColors skillTreeExclusiveLock = new SkillTreeButtonColors
         {
             normal = new Color(0.4f, 0.4f, 0.4f),
             pressed = new Color(0.29803923f, 0.29803923f, 0.29803923f),
-            disabled = new Color(0.2f, 0.2f, 0.2f)
+            disabled = new Color(0.2f, 0.2f, 0.2f),
+            notPurchasableNormal = new Color(0.2f, 0.2f, 0.2f)
         };
 
         // Cached rich text color tags for performance

--- a/Documentation/Code/SkillTreeManager.md
+++ b/Documentation/Code/SkillTreeManager.md
@@ -1,0 +1,46 @@
+# SkillTreeManager
+
+## Purpose and contract
+`SkillTreeManager` is the runtime controller for a single skill node in the skill tree UI. It is responsible for:
+- rendering the node's current state (owned, available, line visibility/color, and theme colors),
+- handling click/right-click behavior (direct buy/unassign vs confirmation flow),
+- enforcing purchase and unassign rules before mutating save state,
+- coordinating with auto-assign lists/presets when skills are removed.
+
+The node's visual state must always match the purchase constraints enforced by `ShowConfirmation` and `PurchaseSkill`.
+
+## Data flow
+1. `UpdateSkill()` refreshes node visibility and visuals from Oracle save state + `SkillDefinition` metadata.
+2. Input path:
+- In tap-to-buy mode (`skillsBuyOnTap == true`), button interactability reflects purchase availability directly.
+- In description mode (`skillsBuyOnTap == false`), the node stays clickable for browsing; the confirmation button enforces purchase gating.
+3. Purchase/unassign path:
+- `PurchaseSkill()` updates Oracle-owned flags, skill points, fragments, and auto-assign/preset queues.
+- `UpdateSkills` event is raised to fan out UI refresh across all nodes/consumers.
+
+## Save/load implications
+- Skill ownership is stored in Oracle/skill-tree save flags keyed by skill IDs.
+- Costs/fragments are read from `SkillDefinition` and applied to `skillPointsTree` / `fragments`.
+- Auto-assign and preset queues are modified on assign/unassign and when dependent skills are removed.
+- Any ID/schema change must be coordinated with `SkillIdMap`, `SkillDatabase`, and save migration compatibility.
+
+## Visual-state behavior (current)
+- Tap-to-buy mode: non-purchasable skills become non-interactable.
+- Description mode: nodes remain clickable; non-purchasable and unowned nodes use `notPurchasableNormal` from the current skill-tree color category.
+- If a theme asset does not define `notPurchasableNormal`, code falls back to a dimmed `normal` color.
+
+## Performance notes
+- `UpdateSkill()` runs frequently via several update events; avoid expensive allocations or broad graph traversals in this path.
+- Dependency traversal methods (`GetOwnedDependentSkillIdsRecursive`/`GetAllDependentSkillIdsRecursive`) are used for unassign operations and can scale with tree size.
+- Keep per-frame/theme color changes lightweight; reuse cached definitions/IDs as currently implemented.
+
+## Quick verification
+1. In description mode (`skillsBuyOnTap = false`):
+- Unowned + purchasable node uses normal color and opens confirmation popup.
+- Unowned + not purchasable node uses dim/not-purchasable color but still opens confirmation popup.
+- Owned node shows purchased marker and remains browsable.
+2. In tap-to-buy mode (`skillsBuyOnTap = true`):
+- Non-purchasable nodes are non-interactable.
+- Purchasable nodes are interactable and can be assigned directly.
+3. Confirm popup:
+- `confirm` button disabled when requirements/cost/exclusive/refundability checks fail.


### PR DESCRIPTION
## Summary
- add a new  color to  and provide defaults for all skill-tree button categories
- update  to keep nodes clickable in description mode while applying a dimmed/not-purchasable visual for unowned skills that fail purchase checks
- keep tap-to-buy behavior unchanged (non-purchasable skills remain non-interactable)
- add required in-file documentation headers and a companion contract doc at 

## Why
- improve skill tree readability in description mode by visually separating purchasable, purchased, and currently non-purchasable skills without blocking browsing

## Testing
- Not run (Unity/manual).