### PR TITLE
fix(save-recovery): add indexed ES3 recovery commands

### DIFF
--- a/Assets/Scripts/Expansion/Oracle.RecoveryCommands.cs
+++ b/Assets/Scripts/Expansion/Oracle.RecoveryCommands.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using QFSW.QC;
+using Systems.Save;
+
+namespace Expansion
+{
+    /// <summary>
+    /// Purpose: manual legacy-save recovery commands exposed through Quantum Console.
+    /// Where it runs: runtime only.
+    /// Primary entry points: <see cref="RecoverPreview"/>, <see cref="RecoverList"/>, <see cref="RecoverApply"/>.
+    /// Owns: preview/apply flow for restoring archived ES3 artifacts into the canonical save pipeline.
+    /// Delegates: artifact selection to <see cref="LegacyEs3Save"/>, persistence/migrations to existing Oracle save APIs.
+    /// </summary>
+    /// <remarks>
+    /// Interacts with:
+    /// - Calls into: <see cref="LegacyEs3Save"/>, <see cref="SavePaths"/>, <see cref="SaveSystem"/>.
+    /// - Invoked by: Quantum Console command scanner (QFSW) at runtime.
+    ///
+    /// Change notes:
+    /// - Command aliases (<c>recover</c>, <c>recover-list</c>, <c>recover-apply</c>) are part of support workflow;
+    ///   changing them breaks runbooks.
+    /// - <see cref="RecoverApply"/> uses 1-based candidate indexing from <see cref="RecoverList"/>.
+    /// - Overwriting canonical save intentionally requires an explicit overwrite flag.
+    /// - Backup naming/location must remain stable for support to locate pre-recovery canonical snapshots.
+    /// </remarks>
+    public partial class Oracle
+    {
+        [Command("recover", "List recoverable legacy ES3 candidates with indexes for manual selection.",
+            MonoTargetType.Single)]
+        public string RecoverPreview()
+        {
+            return RecoverList();
+        }
+
+        [Command("recover-list",
+            "List recoverable legacy ES3 candidates with indexes for manual selection.",
+            MonoTargetType.Single)]
+        public string RecoverList()
+        {
+            List<LegacyEs3RecoveryCandidate> candidates = LegacyEs3Save.GetRecoverableCandidates();
+            if (candidates.Count == 0)
+            {
+                return "[SaveRecovery] No recoverable ES3 artifacts were found.";
+            }
+
+            bool canonicalExists = SaveSystem.CreateDefault().Storage.Exists();
+            string canonicalStatus = canonicalExists
+                ? "Canonical save exists; append `true` to overwrite (example: `recover-apply 1 true`)."
+                : "No canonical save exists; run `recover-apply <index>`.";
+
+            StringBuilder output = new StringBuilder();
+            output.Append($"[SaveRecovery] Found {candidates.Count} recoverable candidate(s). ");
+            output.Append(canonicalStatus);
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                output.AppendLine();
+                output.Append(FormatCandidateLine(i + 1, candidates[i], includePath: false));
+            }
+
+            return output.ToString();
+        }
+
+        [Command("recover-apply",
+            "Apply candidate #1 when no canonical save exists. Use `recover-apply <index> true` to force overwrite.",
+            MonoTargetType.Single)]
+        public string RecoverApply()
+        {
+            return RecoverApplyInternal(index: 1, overwriteCanonical: false);
+        }
+
+        [Command("recover-apply",
+            "Apply a specific candidate index from `recover-list`. Example: `recover-apply 2`.",
+            MonoTargetType.Single)]
+        public string RecoverApply(int index)
+        {
+            return RecoverApplyInternal(index, overwriteCanonical: false);
+        }
+
+        [Command("recover-apply",
+            "Apply a specific candidate index, optionally overwriting canonical save.",
+            MonoTargetType.Single)]
+        public string RecoverApply(int index, bool overwriteCanonical)
+        {
+            return RecoverApplyInternal(index, overwriteCanonical);
+        }
+
+        private string RecoverApplyInternal(int index, bool overwriteCanonical)
+        {
+            if (!TryGetCandidateByIndex(index, out LegacyEs3RecoveryCandidate candidate, out int totalCount,
+                    out string selectionError))
+            {
+                return selectionError;
+            }
+
+            SaveSystem saveSystem = SaveSystem.CreateDefault();
+            bool canonicalExists = saveSystem.Storage.Exists();
+            if (canonicalExists && !overwriteCanonical)
+            {
+                return "[SaveRecovery] Canonical save already exists. " +
+                       $"Run `recover-apply {index} true` to explicitly overwrite it.";
+            }
+
+            string backupPath = null;
+            if (canonicalExists && !TryBackupCanonicalBeforeRecovery(out backupPath, out string backupError))
+            {
+                return "[SaveRecovery] Recovery aborted: failed to back up canonical save before overwrite. " +
+                       $"Error: {backupError}";
+            }
+
+            ApplyLoadedSettings(candidate.Settings, "ES3 (manual recover)");
+            ApplyMigrations();
+            SyncAutoAssignFromSelectedPreset(runAutoAssign: true);
+            UpdateSkills?.Invoke();
+            SaveInternal(force: true, updateQuitTime: false);
+
+            if (!string.IsNullOrEmpty(backupPath))
+            {
+                return $"[SaveRecovery] Recovery applied from candidate #{index} ('{candidate.Path}'). " +
+                       $"Previous canonical save backed up to '{backupPath}'.";
+            }
+
+            return $"[SaveRecovery] Recovery applied from candidate #{index} ('{candidate.Path}') " +
+                   $"out of {totalCount} candidate(s).";
+        }
+
+        private static bool TryGetCandidateByIndex(int index, out LegacyEs3RecoveryCandidate candidate, out int totalCount,
+            out string error)
+        {
+            candidate = default;
+            totalCount = 0;
+            error = null;
+
+            if (index < 1)
+            {
+                error = "[SaveRecovery] Candidate index must be 1 or greater. Run `recover-list` first.";
+                return false;
+            }
+
+            List<LegacyEs3RecoveryCandidate> candidates = LegacyEs3Save.GetRecoverableCandidates();
+            totalCount = candidates.Count;
+            if (totalCount == 0)
+            {
+                error = "[SaveRecovery] No recoverable ES3 artifacts were found.";
+                return false;
+            }
+
+            int zeroBasedIndex = index - 1;
+            if (zeroBasedIndex >= totalCount)
+            {
+                error = $"[SaveRecovery] Candidate #{index} is out of range (found {totalCount}). " +
+                        "Run `recover-list` to see valid indexes.";
+                return false;
+            }
+
+            candidate = candidates[zeroBasedIndex];
+            return true;
+        }
+
+        private static string FormatCandidateLine(int index, LegacyEs3RecoveryCandidate candidate, bool includePath)
+        {
+            string version = candidate.SaveVersion.ToString(CultureInfo.InvariantCulture);
+            string started = string.IsNullOrWhiteSpace(candidate.Settings?.dateStarted)
+                ? "n/a"
+                : candidate.Settings.dateStarted;
+            string quit = string.IsNullOrWhiteSpace(candidate.Settings?.dateQuitString)
+                ? "n/a"
+                : candidate.Settings.dateQuitString;
+            string lastUtc = candidate.TimestampUtc.HasValue
+                ? candidate.TimestampUtc.Value.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture)
+                : "n/a";
+            string source = GetCandidateSourceLabel(candidate.Path);
+            string fileName = Path.GetFileName(candidate.Path);
+            string pathSegment = includePath ? $", path='{candidate.Path}'" : string.Empty;
+
+            return $"[{index}] v{version}, source={source}, file='{fileName}', lastUtc='{lastUtc}', " +
+                   $"dateQuit='{quit}', dateStarted='{started}'{pathSegment}";
+        }
+
+        private static string GetCandidateSourceLabel(string candidatePath)
+        {
+            if (string.IsNullOrEmpty(candidatePath)) return "unknown";
+            if (candidatePath.Contains(".corrupt.")) return "archived-corrupt";
+            if (candidatePath.EndsWith(".tmp.bak", StringComparison.OrdinalIgnoreCase)) return "backup-tmp-bak";
+            if (candidatePath.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase)) return "backup-tmp";
+            if (candidatePath.EndsWith(".bac", StringComparison.OrdinalIgnoreCase)) return "backup-bac";
+            return "primary";
+        }
+
+        private bool TryBackupCanonicalBeforeRecovery(out string backupPath, out string error)
+        {
+            backupPath = null;
+            error = null;
+            try
+            {
+                string canonicalPath = SavePaths.GetCanonicalSavePath();
+                if (!File.Exists(canonicalPath)) return true;
+
+                string backupFolder = SavePaths.GetBackupFolderPath();
+                Directory.CreateDirectory(backupFolder);
+
+                string stamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+                backupPath = Path.Combine(backupFolder, $"manual_recover_preexisting_{stamp}.txt");
+
+                int counter = 1;
+                while (File.Exists(backupPath) && counter < 50)
+                {
+                    backupPath = Path.Combine(backupFolder, $"manual_recover_preexisting_{stamp}.{counter}.txt");
+                    counter++;
+                }
+
+                File.Copy(canonicalPath, backupPath, overwrite: false);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                backupPath = null;
+                error = ex.Message;
+                return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Expansion/Oracle.RecoveryCommands.cs.meta
+++ b/Assets/Scripts/Expansion/Oracle.RecoveryCommands.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b6c53ce504f2432990252b2182c8a31

--- a/Assets/Scripts/Systems/Save/LegacyEs3Save.cs
+++ b/Assets/Scripts/Systems/Save/LegacyEs3Save.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Expansion;
@@ -6,9 +7,42 @@ using UnityEngine;
 
 namespace Systems.Save
 {
+    public readonly struct LegacyEs3RecoveryCandidate
+    {
+        public LegacyEs3RecoveryCandidate(string path, Oracle.SaveDataSettings settings, DateTime? timestampUtc, int trust)
+        {
+            Path = path;
+            Settings = settings;
+            SaveVersion = settings?.saveVersion ?? 0;
+            TimestampUtc = timestampUtc;
+            Trust = trust;
+        }
+
+        public string Path { get; }
+        public Oracle.SaveDataSettings Settings { get; }
+        public int SaveVersion { get; }
+        public DateTime? TimestampUtc { get; }
+        public int Trust { get; }
+    }
+
     /// <summary>
-    /// Legacy ES3 save helpers kept for importing older saves during the Odin-only transition.
+    /// Purpose: legacy ES3 artifact helpers used to import pre-canonical saves during startup recovery.
+    /// Where it runs: runtime only (called from Oracle load/wipe flows).
+    /// Primary entry points: <see cref="DeleteDefaultArtifacts"/>, <see cref="ArchiveDefaultArtifacts"/>,
+    /// <see cref="TryRecoverDefaultSave"/>, <see cref="GetRecoverableCandidates"/>.
+    /// Owns: ES3 file artifact probing, candidate ranking, and legacy format load attempts.
+    /// Delegates: selected save adoption/migrations to <c>Expansion.Oracle</c>.
     /// </summary>
+    /// <remarks>
+    /// Interacts with:
+    /// - Calls into: Easy Save 3 APIs (<c>ES3</c>/<c>ES3Settings</c>) and filesystem APIs.
+    /// - Called by: <c>Assets/Scripts/Expansion/Oracle.Persistence.cs</c>.
+    ///
+    /// Change notes:
+    /// - The key name <c>saveSettings</c> and ES3 default path assumptions must remain aligned with legacy builds.
+    /// - Candidate trust/order affects which historical artifact is chosen when multiple saves exist.
+    /// - Removing legacy AES fallback will regress recovery for encrypted ES3 files archived as <c>.corrupt.*</c>.
+    /// </remarks>
     public static class LegacyEs3Save
     {
         public static void DeleteDefaultArtifacts()
@@ -86,54 +120,12 @@ namespace Systems.Save
             recoveredFromPath = null;
             try
             {
-                ES3Settings settings = new ES3Settings();
-                if (settings.location != ES3.Location.File) return false;
-                string fullPath = settings.FullPath;
-                if (string.IsNullOrEmpty(fullPath)) return false;
+                List<LegacyEs3RecoveryCandidate> candidates = GetRecoverableCandidates();
+                if (candidates.Count == 0) return false;
 
-                // ES3 writes via a temp file and keeps a copy of the previous file at "<fullPath>.tmp.bak".
-                // If the main file is corrupt/truncated or silently loads defaults, the backup artifacts
-                // often still contain the last good save.
-                //
-                // Try all candidates and pick the "best" by:
-                // - saveVersion (higher wins)
-                // - timestamp (later wins; best-effort parse)
-                // - file trust (main > .bac > .tmp.bak > .tmp)
-                string[] candidates =
-                {
-                    fullPath,
-                    fullPath + ".bac",
-                    fullPath + ".tmp.bak",
-                    fullPath + ".tmp"
-                };
-
-                Oracle.SaveDataSettings best = null;
-                string bestPath = null;
-                int bestVersion = -1;
-                DateTime? bestUtc = null;
-                int bestTrust = -1;
-
-                foreach (string candidate in candidates)
-                {
-                    if (!TryLoadSaveSettingsFromEs3File(candidate, out Oracle.SaveDataSettings candidateSettings)) continue;
-
-                    int version = candidateSettings?.saveVersion ?? 0;
-                    DateTime? utc = TryGetCandidateTimestampUtc(candidateSettings, out DateTime parsed) ? parsed : (DateTime?)null;
-                    int trust = GetCandidateTrust(candidate);
-
-                    if (IsBetter(version, utc, trust, bestVersion, bestUtc, bestTrust))
-                    {
-                        best = candidateSettings;
-                        bestPath = candidate;
-                        bestVersion = version;
-                        bestUtc = utc;
-                        bestTrust = trust;
-                    }
-                }
-
-                if (best == null) return false;
-                recovered = best;
-                recoveredFromPath = bestPath;
+                LegacyEs3RecoveryCandidate best = candidates[0];
+                recovered = best.Settings;
+                recoveredFromPath = best.Path;
                 return true;
             }
             catch
@@ -142,6 +134,94 @@ namespace Systems.Save
             }
 
             return false;
+        }
+
+        public static List<LegacyEs3RecoveryCandidate> GetRecoverableCandidates()
+        {
+            var recoverable = new List<LegacyEs3RecoveryCandidate>();
+            try
+            {
+                ES3Settings settings = new ES3Settings();
+                if (settings.location != ES3.Location.File) return recoverable;
+
+                string fullPath = settings.FullPath;
+                if (string.IsNullOrEmpty(fullPath)) return recoverable;
+
+                foreach (string candidatePath in BuildCandidatePathList(fullPath))
+                {
+                    if (!TryLoadSaveSettingsFromEs3File(candidatePath, out Oracle.SaveDataSettings candidateSettings))
+                        continue;
+
+                    DateTime? utc = TryGetCandidateTimestampUtc(candidateSettings, out DateTime parsed)
+                        ? parsed
+                        : (DateTime?)null;
+                    int trust = GetCandidateTrust(candidatePath);
+
+                    var candidate = new LegacyEs3RecoveryCandidate(candidatePath, candidateSettings, utc, trust);
+                    InsertCandidateByPriority(recoverable, candidate);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return recoverable;
+        }
+
+        private static List<string> BuildCandidatePathList(string fullPath)
+        {
+            var candidates = new List<string>
+            {
+                fullPath,
+                fullPath + ".bac",
+                fullPath + ".tmp.bak",
+                fullPath + ".tmp"
+            };
+
+            // Also scan for previously-archived files (*.corrupt.*) from earlier failed load attempts.
+            // These were moved aside before AES fallback existed, so they may actually be valid.
+            try
+            {
+                string dir = Path.GetDirectoryName(fullPath);
+                string baseName = Path.GetFileName(fullPath);
+                if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+                {
+                    foreach (string archived in Directory.GetFiles(dir, baseName + ".corrupt.*"))
+                    {
+                        candidates.Add(archived);
+                    }
+                }
+            }
+            catch
+            {
+                // Non-critical — just skip archived file discovery.
+            }
+
+            return candidates;
+        }
+
+        private static void InsertCandidateByPriority(
+            List<LegacyEs3RecoveryCandidate> ordered,
+            LegacyEs3RecoveryCandidate candidate)
+        {
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                LegacyEs3RecoveryCandidate current = ordered[i];
+                if (IsBetter(
+                        candidate.SaveVersion,
+                        candidate.TimestampUtc,
+                        candidate.Trust,
+                        current.SaveVersion,
+                        current.TimestampUtc,
+                        current.Trust))
+                {
+                    ordered.Insert(i, candidate);
+                    return;
+                }
+            }
+
+            ordered.Add(candidate);
         }
 
         private static bool IsBetter(
@@ -169,6 +249,7 @@ namespace Systems.Save
         {
             // Higher = more trusted.
             if (string.IsNullOrEmpty(candidatePath)) return 0;
+            if (candidatePath.Contains(".corrupt.")) return 0; // Previously archived — least trusted but still worth trying.
             if (candidatePath.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase)) return 1;
             if (candidatePath.EndsWith(".tmp.bak", StringComparison.OrdinalIgnoreCase)) return 2;
             if (candidatePath.EndsWith(".bac", StringComparison.OrdinalIgnoreCase)) return 3;
@@ -212,12 +293,83 @@ namespace Systems.Save
         private static bool TryLoadSaveSettingsFromEs3File(string fullPath, out Oracle.SaveDataSettings settings)
         {
             settings = null;
+            if (string.IsNullOrEmpty(fullPath)) return false;
+            if (!File.Exists(fullPath)) return false;
+
+            // 1) Try with current defaults (no encryption, file location).
+            if (TryEs3KeyExistsAndLoad(fullPath, null, out settings))
+                return true;
+
+            // 2) Older production installs wrote encrypted ES3 files even when current defaults are unencrypted.
+            //    Probe legacy AES settings so encrypted saves are treated as recoverable instead of unrecoverable.
+            if (TryLoadSaveSettingsFromLegacyAes(fullPath, out settings))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryLoadSaveSettingsFromLegacyAes(string fullPath, out Oracle.SaveDataSettings settings)
+        {
+            settings = null;
+
+            foreach (string password in EnumerateLegacyAesPasswords())
+            {
+                ES3Settings aesSettings = new ES3Settings(fullPath)
+                {
+                    encryptionType = ES3.EncryptionType.AES,
+                    encryptionPassword = password,
+                    compressionType = ES3.CompressionType.None
+                };
+
+                if (!TryEs3KeyExistsAndLoad(fullPath, aesSettings, out settings)) continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static System.Collections.Generic.IEnumerable<string> EnumerateLegacyAesPasswords()
+        {
+            var passwords = new System.Collections.Generic.List<string>();
             try
             {
-                if (string.IsNullOrEmpty(fullPath)) return false;
-                if (!File.Exists(fullPath)) return false;
-                if (!ES3.KeyExists("saveSettings", fullPath)) return false;
-                settings = ES3.Load<Oracle.SaveDataSettings>("saveSettings", fullPath);
+                ES3Settings defaults = new ES3Settings();
+                if (!string.IsNullOrWhiteSpace(defaults.encryptionPassword))
+                {
+                    passwords.Add(defaults.encryptionPassword);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            // Legacy ES3 defaults commonly used this password.
+            if (!passwords.Contains("password"))
+            {
+                passwords.Add("password");
+            }
+
+            return passwords;
+        }
+
+        private static bool TryEs3KeyExistsAndLoad(string fullPath, ES3Settings overrideSettings,
+            out Oracle.SaveDataSettings settings)
+        {
+            settings = null;
+            try
+            {
+                bool exists = overrideSettings != null
+                    ? ES3.KeyExists("saveSettings", overrideSettings)
+                    : ES3.KeyExists("saveSettings", fullPath);
+                if (!exists) return false;
+
+                settings = overrideSettings != null
+                    ? ES3.Load<Oracle.SaveDataSettings>("saveSettings", overrideSettings)
+                    : ES3.Load<Oracle.SaveDataSettings>("saveSettings", fullPath);
                 return settings != null;
             }
             catch

--- a/Documentation/Code/LegacyEs3Save.md
+++ b/Documentation/Code/LegacyEs3Save.md
@@ -1,0 +1,35 @@
+# LegacyEs3Save
+
+## Contract / behavior expectations
+- Provides best-effort recovery only for legacy ES3 artifacts; it does not apply migrations or mutate runtime game state directly.
+- Must tolerate corrupted files without throwing to callers.
+- `GetRecoverableCandidates()` returns all valid candidates sorted best-first.
+- Recovery candidate ranking must prioritize:
+  1. higher `saveVersion`,
+  2. newer parsed timestamp (`lastSuccessfulLoadUtc`, then `dateQuitString`, then `dateStarted`),
+  3. trust order (`main` > `.bac` > `.tmp.bak` > `.tmp` > archived `.corrupt.*`).
+- Must support both current unencrypted ES3 files and legacy AES-encrypted ES3 files.
+
+## Data flow
+1. Build candidate path list for default ES3 file and known backup suffixes.
+2. Append archived `.corrupt.*` files if present.
+3. For each candidate:
+   - try default ES3 settings (`ES3.KeyExists` + `ES3.Load`),
+   - then try legacy AES settings with known/default password candidates.
+4. Sort candidates by version/timestamp/trust and return the ordered list.
+5. `TryRecoverDefaultSave` picks index `0` from that list.
+
+## Save/load implications
+- Changing key name `saveSettings` breaks compatibility with all historical ES3 saves.
+- Removing AES fallback causes encrypted legacy files to be treated as unrecoverable.
+- Removing `.corrupt.*` scanning prevents restoring saves that were archived before AES-aware recovery existed.
+
+## Performance pitfalls
+- Directory globbing for `.corrupt.*` is startup-path work; keep it scoped to one directory and one basename.
+- Avoid expensive full-file decode attempts when `ES3.KeyExists` succeeds quickly.
+
+## Quick verification steps
+1. Plain ES3 file: `TryRecoverDefaultSave` returns that file.
+2. AES-encrypted ES3 file (password `password`): recovery succeeds without emitting warning-level probe logs.
+3. Archived encrypted file (`SaveFile.es3.corrupt.*`) with missing main file: candidate list includes archived file.
+4. Random invalid file: methods return no candidate without throwing.

--- a/Documentation/Code/Oracle.RecoveryCommands.md
+++ b/Documentation/Code/Oracle.RecoveryCommands.md
@@ -1,0 +1,37 @@
+# Oracle.RecoveryCommands
+
+## Contract / behavior expectations
+- `recover` must be non-destructive and return the same indexed output as `recover-list`.
+- `recover-list` must print all recoverable candidates with stable 1-based indexes.
+- `recover-apply` must accept indexed selection (`recover-apply <index>`) and restore that candidate into live runtime state, run migrations, and write canonical save.
+- If canonical save already exists, `recover-apply` must require explicit overwrite (`recover-apply <index> true`) to avoid accidental clobbering.
+- Before overwrite, canonical save must be backed up into `SavePaths.GetBackupFolderPath()`.
+
+## Data flow
+1. Commands invoke `LegacyEs3Save.GetRecoverableCandidates()` to get best-first candidates.
+2. `recover` delegates to `recover-list`.
+3. List command returns all candidates with numbered selection lines.
+4. Apply command:
+   - validates index bounds,
+   - validates overwrite flag against canonical presence,
+   - backs up existing canonical save if overwrite is requested,
+   - applies recovered settings (`ApplyLoadedSettings`),
+   - runs migrations and preset sync,
+   - writes canonical save via `SaveInternal(force: true, updateQuitTime: false)`.
+
+## Save/load implications
+- Recovery command writes canonical save immediately, making recovered data the new source of truth.
+- Existing canonical save is only replaced when explicitly requested with overwrite flag.
+- Backup files are named `manual_recover_preexisting_*.txt` to aid support workflows.
+
+## Performance pitfalls
+- Recovery probing deserializes legacy artifacts; avoid repeated command spam in one frame.
+- The command intentionally performs full migration/save work and should be treated as an admin/support action.
+
+## Quick verification steps
+1. Run `recover` with archived `.corrupt.*` files present and verify numbered candidates print.
+2. Run `recover-apply 2` while canonical save exists and verify command refuses overwrite.
+3. Run `recover-apply 2 true` and verify:
+   - backup file is created in save backup folder,
+   - recovered save becomes active,
+   - canonical save is rewritten.


### PR DESCRIPTION
## Summary
- add ordered legacy ES3 recovery candidate discovery in `LegacyEs3Save` (primary, `.bac`, `.tmp.bak`, `.tmp`, and archived `.corrupt.*`)
- retain legacy AES fallback probing so old encrypted ES3 artifacts can be read during recovery
- add QFSW console recovery commands in `Oracle.RecoveryCommands`:
  - `recover` (delegates to list output)
  - `recover-list`
  - `recover-apply <index>` and `recover-apply <index> true`
- require explicit overwrite flag when canonical save exists and preserve pre-overwrite backup behavior
- remove warning-level probe logs that produced noisy stack traces during preview/listing
- add companion docs for recovery command and legacy ES3 behavior

## Testing
- Not run (Unity/manual).
