### PR TITLE
fix(offlinesystem): isolate quit timestamp lifecycle

### DIFF
--- a/Assets/Scripts/Expansion/Oracle.Persistence.cs
+++ b/Assets/Scripts/Expansion/Oracle.Persistence.cs
@@ -21,6 +21,8 @@ namespace Expansion
     /// Runtime.
     /// <para>Primary entry points: <see cref="Load"/>, <see cref="WipeAllData"/>, <see cref="LoadState"/>.</para>
     /// <para>Owns: startup load-source selection and wipe orchestration.</para>
+    /// <para>Diagnostics: writes one tagged warning per save lifecycle event plus offline-time replay data via
+    /// <see cref="AwayForSeconds"/>.</para>
     /// <para>Delegates: ES3 artifact probing to <see cref="LegacyEs3Save"/>, codec/storage to
     /// <see cref="SaveCodec"/>/<see cref="SaveSystem"/>.</para>
     /// Canonical persistence stores the exact same save string used by clipboard export/import (prefix <c>IDB1:</c>).
@@ -38,15 +40,40 @@ namespace Expansion
     /// </remarks>
     public partial class Oracle
     {
-        private void SaveInternal(bool force, bool updateQuitTime = true)
+        private void SaveInternal(bool force, bool updateQuitTime = false)
         {
-            if (!_isSaveReady && !force) return;
+            if (!_isSaveReady && !force)
+            {
+                if (updateQuitTime)
+                {
+                    Debug.LogWarning(
+                        $"[OfflineTimeDiag] SaveInternalBlocked | phase=SaveInternal, reason=not_ready, platform={Application.platform}, " +
+                        $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                        $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+                }
+                return;
+            }
+            string dateSource = "none";
             if (updateQuitTime)
             {
-                saveSettings.dateQuitString = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+                dateSource = "updated";
+                SetDateQuitString(DateTime.UtcNow.ToString(CultureInfo.InvariantCulture), isQuitTimestamp: true);
             }
 
-            SaveState();
+            bool saved = TrySaveState(out string saveError);
+            string status = saved ? "ok" : "failed";
+            string details = $"phase=SaveInternal, platform={Application.platform}, force={force.ToString().ToLowerInvariant()}, dateSource={dateSource}, " +
+                             $"saveResult={status}, path='{SavePaths.GetCanonicalSavePath()}', quit={FormatDebugString(saveSettings.dateQuitString)}, " +
+                             $"offlineTime={saveSettings.offlineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                             $"maxOfflineTime={saveSettings.maxOfflineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                             $"loaded={Loaded.ToString().ToLowerInvariant()}, ready={_isSaveReady.ToString().ToLowerInvariant()}";
+            if (!string.IsNullOrWhiteSpace(saveError))
+            {
+                details += $", error={FormatDebugString(saveError)}";
+            }
+
+            Debug.LogWarning($"[OfflineTimeDiag] {details}");
+            if (!saved) return;
         }
 
         private static void DeleteDefaultEs3SaveArtifacts()
@@ -168,11 +195,23 @@ namespace Expansion
         [ContextMenu("Save")]
         public void Save()
         {
-            SaveInternal(false);
+            SaveInternal(false, updateQuitTime: false);
         }
 
-        public void SaveState()
+        public void SaveForQuit()
         {
+            SaveInternal(force: true, updateQuitTime: true);
+        }
+
+        private void SetDateQuitString(string value, bool isQuitTimestamp = false)
+        {
+            if (!isQuitTimestamp || saveSettings == null) return;
+            saveSettings.dateQuitString = value;
+        }
+
+        public bool TrySaveState(out string error)
+        {
+            error = null;
             SaveDictionaries();
             PackSettingsFlags();
             SaveDataSettings snapshot = SaveSnapshotBuilder.CreateSaveSnapshotForStorage(
@@ -182,10 +221,19 @@ namespace Expansion
                 getAutoAssignmentSkillIds: GetAutoAssignmentSkillIds);
 
             SaveSystem saveSystem = SaveSystem.CreateDefault();
-            if (!saveSystem.TrySave(snapshot, out _, out string error))
+            if (!saveSystem.TrySave(snapshot, out _, out string saveError))
             {
+                error = saveError;
                 Debug.LogError($"[Save] Failed writing canonical save file: {error}");
+                return false;
             }
+
+            return true;
+        }
+
+        public void SaveState()
+        {
+            TrySaveState(out string _);
         }
 
         private byte[] BuildOwnedBitsetFromRuntime()
@@ -371,14 +419,21 @@ namespace Expansion
 
         private void AwayForSeconds()
         {
-            if (string.IsNullOrEmpty(oracle.saveSettings.dateQuitString)) return;
+            if (string.IsNullOrEmpty(oracle.saveSettings.dateQuitString))
+            {
+                Debug.LogWarning($"[OfflineTimeDiag] AwayForSeconds | platform={Application.platform}, dateQuitString_missing=true");
+                return;
+            }
             DateTime dateStarted;
+            string dateSource = "quitString";
             if (!DateTime.TryParse(oracle.saveSettings.dateQuitString, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out dateStarted))
             {
+                dateSource = "dateStartedFallback";
                 if (!DateTime.TryParse(oracle.saveSettings.dateStarted, CultureInfo.InvariantCulture,
                         DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out dateStarted))
                 {
+                    dateSource = "runtimeUtcFallback";
                     dateStarted = DateTime.UtcNow;
                 }
             }
@@ -386,9 +441,33 @@ namespace Expansion
             DateTime dateNow = DateTime.UtcNow;
             TimeSpan timespan = dateNow - dateStarted;
             float seconds = (float)timespan.TotalSeconds;
+            float clampedSeconds = Math.Max(0, seconds);
+            Debug.LogWarning(
+                "[OfflineTimeDiag] AwayForSeconds | " +
+                    $"platform={Application.platform}, " +
+                    $"dateSource={dateSource}, " +
+                $"dateQuit='{FormatDebugString(oracle.saveSettings.dateQuitString)}', " +
+                $"dateStarted='{FormatDebugString(oracle.saveSettings.dateStarted)}', " +
+                $"resolvedStart='{FormatUtc(dateStarted)}', now='{FormatUtc(dateNow)}', " +
+                $"awayRawSeconds={seconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"awayClampedSeconds={clampedSeconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"offlineTime={saveSettings.offlineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                $"maxOfflineTime={saveSettings.maxOfflineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                $"doubleTimeBefore={saveSettings.sdPrestige.doubleTime.ToString(CultureInfo.InvariantCulture)}");
             if (seconds < 0) seconds = 0;
             saveSettings.sdPrestige.doubleTime += seconds;
             AwayFor?.Invoke(seconds);
+        }
+
+        private static string FormatDebugString(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "n/a" : value;
+        }
+
+        private static string FormatUtc(DateTime value)
+        {
+            if (value == default) return "0001-01-01T00:00:00.0000000Z";
+            return value.ToString("o", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -309,26 +309,47 @@ private void PackSettingsFlags()
 
         private void OnApplicationQuit()
         {
-            Save();
+            Debug.LogWarning(
+                $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationQuit, platform={Application.platform}, " +
+                $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+            SaveForQuit();
         }
 
         #if !UNITY_EDITOR
-    void OnApplicationFocus(bool focus)
-    {
-        if (focus)
+        #if UNITY_IOS || UNITY_ANDROID
+        void OnApplicationPause(bool pauseStatus)
         {
+            if (!pauseStatus) return;
+
+            Debug.LogWarning(
+                $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationPause, platform={Application.platform}, " +
+                $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+            SaveForQuit();
+        }
+        #endif
+
+        void OnApplicationFocus(bool focus)
+        {
+            if (focus)
+            {
 #if UNITY_IOS
             Load();
 #elif UNITY_ANDROID
             Load();
 #endif
-        }
-        if (!focus)
-        {
-            Save();
-        }
-    }
-        #endif
+            }
+                if (!focus)
+                {
+                    Debug.LogWarning(
+                        $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationFocusLost, platform={Application.platform}, " +
+                        $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                        $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+                    SaveForQuit();
+                }
+            }
+            #endif
 
 
         #region NewsTicker

--- a/Assets/Scripts/Systems/OfflineProgressSystem.cs
+++ b/Assets/Scripts/Systems/OfflineProgressSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Globalization;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -13,10 +14,11 @@ namespace Systems
      * OfflineProgressSystem
      * Purpose: Applies and simulates "away time" (offline/consumable time) progress for DysonVerse in fixed time steps.
      * Runs: Runtime (coroutines executed from GameManager when returning from idle or spending stored offline time).
+     * Diagnostics: emits a single tagged warning in ApplyReturnValues for each return grant.
      * Entry points:
      * - ApplyReturnValues(double, OfflineProgressContext, OfflineProgressUI): Updates saveSettings.offlineTime and UI text for "Welcome Back".
      * - CalculateAwayValues(double, OfflineProgressContext, OfflineProgressUI): Coroutine that advances production and resources, optionally updating UI.
-     *
+     * 
      * Interacts with:
      * - Expansion.Oracle (skill timers via AddSkillTimerSeconds; saveSettings via caller context)
      * - GameManager (creates context/UI; provides delegates like CalculateProduction, MoneyToAdd, etc.)
@@ -227,6 +229,11 @@ namespace Systems
             if (!ValidateContext(context)) return;
             SanitizeInfinityData(context.infinityData);
 
+            double beforeOfflineTime = context.saveSettings.offlineTime;
+            bool capApplied = false;
+            double calculatedAwayTime;
+            string result = "ok";
+
             string color = "<color=#91DD8F>";
             string colorS = "<color=#00E1FF>";
             ui?.AwayForHeader?.gameObject.SetActive(true);
@@ -235,6 +242,7 @@ namespace Systems
             ui?.OfflineTimeInstructions?.SetActive(true);
             if (awayTime < 0)
             {
+                result = "cheater_reset";
                 context.saveSettings.cheater = true;
                 context.saveSettings.offlineTime = 0;
                 context.saveSettings.maxOfflineTime = 0;
@@ -242,14 +250,21 @@ namespace Systems
                 text +=
                     "<br>You're probably cheating: Offline time disabled. <br>Please wipe your save to continue using offline time.";
                 if (ui?.AwayFor != null) ui.AwayFor.text = text;
+                Debug.LogWarning(
+                    "[OfflineTimeDiag] ApplyReturnValues | " +
+                    $"platform={Application.platform}, " +
+                    $"result={result}, awayRaw={awayTime.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                    $"beforeOfflineTime={beforeOfflineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                    $"afterOfflineTime={context.saveSettings.offlineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                    $"maxOfflineTime={context.saveSettings.maxOfflineTime.ToString(CultureInfo.InvariantCulture)}");
                 return;
             }
 
-            double calculatedAwayTime;
             if (awayTime >= context.saveSettings.maxOfflineTime - context.saveSettings.offlineTime)
             {
                 calculatedAwayTime = context.saveSettings.maxOfflineTime - context.saveSettings.offlineTime;
                 context.saveSettings.offlineTime = context.saveSettings.maxOfflineTime;
+                capApplied = true;
             }
             else
             {
@@ -261,6 +276,15 @@ namespace Systems
             text1 += $"<br>You have {colorS}{CalcUtils.FormatTimeLarge(context.saveSettings.offlineTime)}</color> stored";
             if (ui?.AwayFor != null) ui.AwayFor.text = text1;
             if (ui?.Amounts != null) ui.Amounts.text = "";
+            Debug.LogWarning(
+                "[OfflineTimeDiag] ApplyReturnValues | " +
+                $"platform={Application.platform}, " +
+                $"result={result}, awayRaw={awayTime.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"applied={calculatedAwayTime.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"beforeOfflineTime={beforeOfflineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                $"afterOfflineTime={context.saveSettings.offlineTime.ToString(CultureInfo.InvariantCulture)}, " +
+                $"capApplied={capApplied.ToString().ToLowerInvariant()}, " +
+                $"maxOfflineTime={context.saveSettings.maxOfflineTime.ToString(CultureInfo.InvariantCulture)}");
         }
 
         public static IEnumerator CalculateAwayValues(double awayTime, OfflineProgressContext context, OfflineProgressUI ui)

--- a/Documentation/Code/OfflineProgressSystem.md
+++ b/Documentation/Code/OfflineProgressSystem.md
@@ -37,6 +37,8 @@ The system should still advance save data even without UI.
 - `SaveDataSettings.offlineTime` is increased in `ApplyReturnValues` and decreased elsewhere when spent.
 - `CalculateAwayValues` mutates `DysonVerseInfinityData` and `DysonVersePrestigeData` in-place.
 - Some `DysonVerseInfinityData` arrays are expected to be length 2. Older saves/migrations can leave new arrays null; the system now sanitizes these arrays before simulation.
+- On desktop/mobile startup, return-time diagnostics are now emitted as one `[OfflineTimeDiag]` warning from `Oracle.AwayForSeconds` and one from
+  `Systems.OfflineProgressSystem.ApplyReturnValues` whenever grant processing occurs.
 
 ## Performance Notes
 - The coroutine steps once per simulated minute and yields each iteration; large `awayTime` values can take noticeable real time to simulate.
@@ -49,4 +51,3 @@ The system should still advance save data even without UI.
    - production/resources advance by the selected amount
 3. Temporarily unassign one or more return-screen UI references on `GameManager` (e.g., `awayForHeader`) and repeat step 2.
    - Expect: simulation still runs; UI updates are skipped where references are missing.
-

--- a/Documentation/Code/Oracle.Persistence.md
+++ b/Documentation/Code/Oracle.Persistence.md
@@ -16,6 +16,21 @@
 4. Best candidate is applied with `ApplyLoadedSettings()`.
 5. Migrations run (`ApplyMigrations()`), runtime sync hooks run, autosave readiness restored.
 
+## Offline timing diagnostics
+- Runtime emits `[OfflineTimeDiag]` warnings from:
+  - `Oracle.OnApplicationQuit`, `Oracle.OnApplicationFocus`, and `Oracle.OnApplicationPause` (platform/ready/loaded/dateQuit pre-save) via `SaveForQuit`
+  - `Oracle.SaveInternal` (save lifecycle snapshots when quit timestamp is updated or save fails)
+  - `Oracle.AwayForSeconds` (chosen source, parsed timestamps, and resolved away span)
+  - `Systems.OfflineProgressSystem.ApplyReturnValues` (pre/post `offlineTime` grant)
+
+## Save lifecycle semantics
+- `Oracle.Save()` is a regular autosave path and **does not** update `dateQuitString`.
+- Quit/focus-loss timestamp should be written only by `Oracle.SaveForQuit()`, which is called from:
+  - `Oracle.OnApplicationQuit`
+  - `Oracle.OnApplicationFocus` when focus is lost (non-editor builds)
+  - `Oracle.OnApplicationPause` while paused (iOS/Android)
+- `Oracle.SaveInternal` now uses `SetDateQuitString(string value, bool isQuitTimestamp = false)` to update `dateQuitString` only when `isQuitTimestamp` is explicitly true.
+
 ## Save/load implications
 - Legacy ES3 key name remains `saveSettings`; changing this breaks import of historic installs.
 - Legacy Odin filename remains derived from `fileName` (`betaTestTwo.idsOdin`).


### PR DESCRIPTION
## Why
Offline progress was intermittently wrong because normal autosaves updated dateQuitString, causing launch-time away-time to be treated as a recent quit instead of actual elapsed time.

## What changed
- Decoupled quit-timestamp updates from regular Save() and made SaveForQuit() the only explicit lifecycle path for dateQuitString.
- Added a guarded date-quittimestamp setter so normal saves cannot accidentally rewrite the quit marker.
- Added focused diagnostics for save lifecycle, away-time parsing, and offline grant application.
- Added mobile background persistence via OnApplicationPause on iOS/Android.
- Kept regular progress persistence behavior unchanged.

## Testing
- Not run (Unity/manual)'