### PR TITLE
fix(persistence): guard quit-save during load

### DIFF
--- a/Assets/Scripts/Expansion/Oracle.Persistence.cs
+++ b/Assets/Scripts/Expansion/Oracle.Persistence.cs
@@ -200,7 +200,21 @@ namespace Expansion
 
         public void SaveForQuit()
         {
-            SaveInternal(force: true, updateQuitTime: true);
+            if (!_isSaveReady || !Loaded || saveSettings == null)
+            {
+                string reason = "unknown";
+                if (saveSettings == null) reason = "missing_save_settings";
+                else if (!_isSaveReady) reason = "not_ready";
+                else if (!Loaded) reason = "not_loaded";
+
+                Debug.LogWarning(
+                    $"[OfflineTimeDiag] SaveForQuitBlocked | phase=SaveForQuit, platform={Application.platform}, " +
+                    $"reason={reason}, ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                    $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+                return;
+            }
+
+            SaveInternal(force: false, updateQuitTime: true);
         }
 
         private void SetDateQuitString(string value, bool isQuitTimestamp = false)

--- a/Documentation/Code/Oracle.Persistence.md
+++ b/Documentation/Code/Oracle.Persistence.md
@@ -25,11 +25,13 @@
 
 ## Save lifecycle semantics
 - `Oracle.Save()` is a regular autosave path and **does not** update `dateQuitString`.
-- Quit/focus-loss timestamp should be written only by `Oracle.SaveForQuit()`, which is called from:
+- `Oracle.SaveForQuit()` writes the quit timestamp only when the runtime is ready + loaded (`_isSaveReady && Loaded && saveSettings != null`).
+- `Oracle.SaveForQuit()` is called from:
   - `Oracle.OnApplicationQuit`
   - `Oracle.OnApplicationFocus` when focus is lost (non-editor builds)
   - `Oracle.OnApplicationPause` while paused (iOS/Android)
 - `Oracle.SaveInternal` now uses `SetDateQuitString(string value, bool isQuitTimestamp = false)` to update `dateQuitString` only when `isQuitTimestamp` is explicitly true.
+- `Oracle.SaveForQuit()` now emits `[OfflineTimeDiag] SaveForQuitBlocked` when lifecycle persistence is attempted before readiness/loading and skips writing.
 
 ## Save/load implications
 - Legacy ES3 key name remains `saveSettings`; changing this breaks import of historic installs.


### PR DESCRIPTION
## Why
Quit persistence was still able to run during startup/loading when save readiness was not established, which could persist wiped or partial in-memory state.

## What changed
- Added readiness gating in SaveForQuit: require save ready + loaded + save settings before writing.
- Added explicit SaveForQuitBlocked diagnostic for skipped lifecycle saves attempted too early.
- Kept quit timestamp updates on the same guarded SaveForQuit path used by quit/focus/pause callbacks.