### PR TITLE
fix(skills): move versatile production tactics bonus to ai managers

### DIFF
--- a/Assets/Data/Databases/EffectDatabase.asset
+++ b/Assets/Data/Databases/EffectDatabase.asset
@@ -135,6 +135,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a2b2df0077f8f394598e141dea7ae396, type: 2}
   - {fileID: 11400000, guid: 144fb3f6220b6534695d92f08e5e4b44, type: 2}
   - {fileID: 11400000, guid: a6b82eec160715a4fb1611bd18289bfc, type: 2}
+  - {fileID: 11400000, guid: 139f5528b770437ca38e767b053234db, type: 2}
   - {fileID: 11400000, guid: ac1dbf27bef3b7e4f94cb2da123a228b, type: 2}
   - {fileID: 11400000, guid: 8340340540b9a2d43ac1370cabc9024e, type: 2}
   - {fileID: 11400000, guid: 85a69f994e133f24a985b7da7e2a7821, type: 2}

--- a/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset
+++ b/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset
@@ -6,20 +6,17 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e43fa0fc22f4af64ab7fb6a2ce9da960, type: 3}
-  m_Name: effect.versatileProductionTactics.assembly_lines_modifier
   m_EditorClassIdentifier: Assembly-CSharp::GameData.EffectDefinition
-  id: effect.versatileProductionTactics.assembly_lines_modifier
+  m_Name: effect.versatileProductionTactics.planets_modifier
+  id: effect.versatileProductionTactics.planets_modifier
   displayName: Versatile Production Tactics
-  targetStatId: Facility.Manager.Production
+  targetStatId: Facility.Planet.Modifier
   operation: 1
   value: 1
   perLevel: 0
   order: 62
   conditionId: 
-  targetFacilityIds:
-  - ai_managers
+  targetFacilityIds: []
   targetFacilityTags: []

--- a/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset.meta
+++ b/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 139f5528b770437ca38e767b053234db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Skills/versatileProductionTactics.asset
+++ b/Assets/Data/Skills/versatileProductionTactics.asset
@@ -17,8 +17,8 @@ MonoBehaviour:
   description: Stuff happens, and your production layout is prepared for everything
     and anything. This allows for a flexible production boost, boosting the highest
     and the lowest layer of the dyson swarm.
-  technicalDescription: You now produce <color=#A3FFFE>50%</color> more <color=#A3FFFE>Assembly
-    Lines</color>. Additionally, after <color=#A3FFFE>100 Planets</color>, <color=#A3FFFE>Planets</color>
+  technicalDescription: You now produce <color=#A3FFFE>50%</color> more <color=#A3FFFE>AI
+    Managers</color>. Additionally, after <color=#A3FFFE>100 Planets</color>, <color=#A3FFFE>Planets</color>
     production boosted by <color=#A3FFFE>50%</color>
   cost: 1
   refundable: 1
@@ -36,4 +36,4 @@ MonoBehaviour:
   unrefundableWithIds: []
   effects:
   - {fileID: 11400000, guid: a6b82eec160715a4fb1611bd18289bfc, type: 2}
-  - {fileID: 11400000, guid: e4e96832a2f46d14bbc0cfd705837d6b, type: 2}
+  - {fileID: 11400000, guid: 139f5528b770437ca38e767b053234db, type: 2}


### PR DESCRIPTION
- Move Versatile Production Tactics from assembly-line modifier to AI manager production for the 50% bonus.
- Keep the existing 100+ planets threshold behavior for planet output unchanged.
- Update skill technical description to describe AI Managers instead of Assembly Lines.