### PR TITLE
feat(ui): wire skill preset toggles in settings window

### DIFF
--- a/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset
+++ b/Assets/Data/Effects/effect.versatileProductionTactics.planets_modifier.asset
@@ -6,8 +6,10 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e43fa0fc22f4af64ab7fb6a2ce9da960, type: 3}
   m_EditorClassIdentifier: Assembly-CSharp::GameData.EffectDefinition
   m_Name: effect.versatileProductionTactics.planets_modifier
   id: effect.versatileProductionTactics.planets_modifier

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -341,7 +341,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1562264}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -540,6 +540,73 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5352893
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5352894}
+  - component: {fileID: 5352895}
+  m_Layer: 5
+  m_Name: PresetToggles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5352894
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5352893}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 115361463}
+  - {fileID: 1784663544}
+  - {fileID: 793060227}
+  - {fileID: 512951436}
+  - {fileID: 29212112}
+  m_Father: {fileID: 1226816661}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 250, y: -227.53}
+  m_SizeDelta: {x: 480, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5352895
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5352893}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 12
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 1
+  m_ReverseArrangement: 0
 --- !u!1 &6275951
 GameObject:
   m_ObjectHideFlags: 0
@@ -5367,6 +5434,134 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 29130488}
   m_CullTransparentMesh: 1
+--- !u!1001 &29212111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5352894}
+    m_Modifications:
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_text
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5797591416764135029, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Name
+      value: Preset Toggle (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+--- !u!224 &29212112 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 29212111}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &29212113 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 29212111}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &29212114 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9174249313873004265, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 29212111}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &29972990
 GameObject:
   m_ObjectHideFlags: 0
@@ -6266,10 +6461,10 @@ RectTransform:
   - {fileID: 1732295447}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -630.04}
+  m_SizeDelta: {x: 1842.827, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &36038277
 MonoBehaviour:
@@ -16997,6 +17192,146 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 99467619}
   m_CullTransparentMesh: 1
+--- !u!1 &101631750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 101631751}
+  - component: {fileID: 101631753}
+  - component: {fileID: 101631752}
+  m_Layer: 5
+  m_Name: FeedbackMessage (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &101631751
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101631750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1226816661}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 250, y: -153.775}
+  m_SizeDelta: {x: 480, y: 67.51}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &101631752
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101631750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Swap presets from the side panel at any time.
+
+    Use Copy and Paste
+    to move presets between slots or share them.'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_sharedMaterial: {fileID: -6419816020481481130, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 22
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 16
+  m_fontSizeMax: 18
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 10, y: 0, z: 20, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &101631753
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101631750}
+  m_CullTransparentMesh: 1
 --- !u!1 &102130828
 GameObject:
   m_ObjectHideFlags: 0
@@ -20588,6 +20923,130 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 115016997}
   m_CullTransparentMesh: 1
+--- !u!1001 &115361462
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5352894}
+    m_Modifications:
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5797591416764135029, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Name
+      value: Preset_Toggle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+--- !u!224 &115361463 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 115361462}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &115361464 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 115361462}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &115361465 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9174249313873004265, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 115361462}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &115436243
 GameObject:
   m_ObjectHideFlags: 0
@@ -21192,7 +21651,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 117854996}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -21372,10 +21831,10 @@ RectTransform:
   - {fileID: 273144127}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -527.535}
+  m_SizeDelta: {x: 1842.827, y: 115.009995}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &117908640
 MonoBehaviour:
@@ -24791,7 +25250,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 135936332}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -36376,10 +36835,10 @@ RectTransform:
   - {fileID: 976033691}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -300.01}
+  m_SizeDelta: {x: 1842.827, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &194052681
 MonoBehaviour:
@@ -41983,7 +42442,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -898.7483, y: 31}
+  m_AnchoredPosition: {x: -898.90704, y: 31}
   m_SizeDelta: {x: 0, y: 55}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &223457327
@@ -44956,7 +45415,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1384954237}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -47604,13 +48063,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846120313231, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Copy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846120313231, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 27.85
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846120313231, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846120313231, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846120313231, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -47828,13 +48295,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846428762170, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Copy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846428762170, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 27.85
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846428762170, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846428762170, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846428762170, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -47916,13 +48391,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846471138760, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Paste
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846471138760, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 26.05
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846471138760, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846471138760, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846471138760, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48036,13 +48519,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846621921713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Paste
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846621921713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 26.05
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846621921713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846621921713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846621921713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48144,13 +48635,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846843000209, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Copy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846843000209, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 27.85
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846843000209, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846843000209, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846843000209, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48192,13 +48691,21 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846893939812, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Copy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765846893939812, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 27.85
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765846893939812, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765846893939812, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765846893939812, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48416,13 +48923,21 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847040740713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Paste
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765847040740713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 26.05
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847040740713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765847040740713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765847040740713, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48552,13 +49067,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847096466704, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Paste
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765847096466704, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 26.05
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847096466704, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765847096466704, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765847096466704, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -48764,13 +49287,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847409620165, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Paste
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765847409620165, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 26.05
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847409620165, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765847409620165, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765847409620165, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -49160,13 +49691,21 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847832266839, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_text
+      value: Copy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7470765847832266839, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontSize
-      value: 27.85
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7470765847832266839, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_fontAsset
       value: 
       objectReference: {fileID: 11400000, guid: 34bc7e54620b8d34d88b7e42acd6b463, type: 2}
+    - target: {fileID: 7470765847832266839, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 7470765847832266839, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
       propertyPath: m_sharedMaterial
       value: 
@@ -49385,7 +49924,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7470765846822556339, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      insertIndex: 2
+      addedObject: {fileID: 101631751}
+    - targetCorrespondingSourceObject: {fileID: 7470765846822556339, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+      insertIndex: 4
+      addedObject: {fileID: 5352894}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
 --- !u!1 &256684218 stripped
@@ -50581,7 +51126,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 260071019}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -53075,10 +53620,10 @@ RectTransform:
   - {fileID: 968449007}
   m_Father: {fileID: 117908639}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 921.4135, y: -85.009995}
+  m_SizeDelta: {x: 1842.827, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &273144128
 MonoBehaviour:
@@ -64443,7 +64988,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 576767549}
+  m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 1724408758}
   m_HandleRect: {fileID: 576767546}
   m_Direction: 0
@@ -72650,7 +73195,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 377218753}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -75269,7 +75814,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 390516646}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -80861,7 +81406,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 417325691}
+  m_TargetGraphic: {fileID: 0}
   m_TextViewport: {fileID: 838513198}
   m_TextComponent: {fileID: 770449857}
   m_Placeholder: {fileID: 2053076775}
@@ -87102,7 +87647,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 446824606}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -92726,10 +93271,10 @@ RectTransform:
   - {fileID: 497736889}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -370.02002}
+  m_SizeDelta: {x: 1842.827, y: 60.02}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &473176547
 MonoBehaviour:
@@ -96760,10 +97305,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 473176546}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 921.4135, y: -45.015}
+  m_SizeDelta: {x: 1842.827, y: 30.01}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &497736890
 MonoBehaviour:
@@ -99122,6 +99667,134 @@ MonoBehaviour:
   - {fileID: 1137891571}
   - {fileID: 1326732875}
   - {fileID: 410040185}
+--- !u!1001 &512951435
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5352894}
+    m_Modifications:
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_text
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5797591416764135029, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Name
+      value: Preset Toggle (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+--- !u!224 &512951436 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 512951435}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &512951437 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 512951435}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &512951438 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9174249313873004265, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 512951435}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &513850731
 GameObject:
   m_ObjectHideFlags: 0
@@ -107954,10 +108627,10 @@ RectTransform:
   - {fileID: 1661158856}
   m_Father: {fileID: 36038276}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1153.0168, y: -25}
+  m_SizeDelta: {x: 453.20676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &563689732
 MonoBehaviour:
@@ -109492,8 +110165,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 898242498}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.7209997, y: 0}
+  m_AnchorMax: {x: 0.7209997, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 30, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -110570,10 +111243,10 @@ RectTransform:
   - {fileID: 1598929802}
   m_Father: {fileID: 117908639}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 921.4135, y: -22.505}
+  m_SizeDelta: {x: 1842.827, y: 45.01}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &583485420
 MonoBehaviour:
@@ -133620,7 +134293,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 687595185}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -136468,7 +137141,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 712713362}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -150765,6 +151438,134 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1001 &793060226
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5352894}
+    m_Modifications:
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_text
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5797591416764135029, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Name
+      value: Preset Toggle (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+--- !u!224 &793060227 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 793060226}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &793060228 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 793060226}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &793060229 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9174249313873004265, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 793060226}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &795009321
 GameObject:
   m_ObjectHideFlags: 0
@@ -155843,7 +156644,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 822171096}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -156167,9 +156968,9 @@ RectTransform:
   m_Father: {fileID: 106492397}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &824766212
 MonoBehaviour:
@@ -160199,7 +161000,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1603468644}
+  m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 881106080}
   m_HandleRect: {fileID: 1603468641}
   m_Direction: 0
@@ -164510,10 +165311,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -42.505}
+  m_SizeDelta: {x: 1842.827, y: 85.01}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &877266485
 MonoBehaviour:
@@ -172420,7 +173221,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 927880659}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -173728,7 +174529,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 933019526}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -180736,10 +181537,10 @@ RectTransform:
   - {fileID: 2020387094}
   m_Father: {fileID: 273144127}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1384.6202, y: -30}
+  m_SizeDelta: {x: 916.4135, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &968449008
 MonoBehaviour:
@@ -181677,10 +182478,10 @@ RectTransform:
   - {fileID: 2069671930}
   m_Father: {fileID: 194052680}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1384.6202, y: -30}
+  m_SizeDelta: {x: 916.4135, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &976033692
 MonoBehaviour:
@@ -202597,7 +203398,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1109144724}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -203916,7 +204717,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1118815125
 RectTransform:
   m_ObjectHideFlags: 0
@@ -207449,7 +208250,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1137728302}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -214394,7 +215195,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1173432759}
+  m_TargetGraphic: {fileID: 0}
   m_Template: {fileID: 881354938}
   m_CaptionText: {fileID: 902471152}
   m_CaptionImage: {fileID: 0}
@@ -214600,7 +215401,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -0.000030517578, y: -1141}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 710.05}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1175548421
 MonoBehaviour:
@@ -217318,10 +218119,10 @@ RectTransform:
   - {fileID: 948694210}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -177.51001}
+  m_SizeDelta: {x: 1842.827, y: 165}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1193830122
 MonoBehaviour:
@@ -224845,7 +225646,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1226319901}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -225016,6 +225817,11 @@ MonoBehaviour:
     - {r: 0, g: 0, b: 0, a: 0}
     - {r: 0, g: 0, b: 0, a: 0}
     m_Rotation: 135
+--- !u!224 &1226816661 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7470765846822556339, guid: f97b0ec011a6e8c4a802e97a64cda50c, type: 3}
+  m_PrefabInstance: {fileID: 256684217}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1227905288
 GameObject:
   m_ObjectHideFlags: 0
@@ -229190,10 +229996,10 @@ RectTransform:
   - {fileID: 585162918}
   m_Father: {fileID: 36038276}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 226.60338, y: -25}
+  m_SizeDelta: {x: 453.20676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1247382740
 MonoBehaviour:
@@ -249000,7 +249806,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1357985906}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -249310,10 +250116,10 @@ RectTransform:
   - {fileID: 1104257268}
   m_Father: {fileID: 273144127}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 458.20676, y: -30}
+  m_SizeDelta: {x: 916.4135, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1359129962
 MonoBehaviour:
@@ -252998,7 +253804,7 @@ RectTransform:
   m_Father: {fileID: 1266501224}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 19, y: 19}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -276187,7 +276993,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1782659540}
+  m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 2004027886}
   m_HandleRect: {fileID: 1782659537}
   m_Direction: 0
@@ -276478,10 +277284,10 @@ RectTransform:
   - {fileID: 177774164}
   m_Father: {fileID: 194052680}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 458.20676, y: -30}
+  m_SizeDelta: {x: 916.4135, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1506955042
 MonoBehaviour:
@@ -282787,10 +283593,10 @@ RectTransform:
   - {fileID: 969817934}
   m_Father: {fileID: 36038276}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 689.8101, y: -25}
+  m_SizeDelta: {x: 453.20676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1538567019
 MonoBehaviour:
@@ -285587,7 +286393,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1556160005}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -286440,7 +287246,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 0
-  m_TargetGraphic: {fileID: 1558113376}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -287614,7 +288420,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1561066412}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -291466,7 +292272,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1588533360}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -301429,7 +302235,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1804375153}
+  m_TargetGraphic: {fileID: 0}
   toggleTransition: 1
   graphic: {fileID: 76362747}
   m_Group: {fileID: 0}
@@ -316697,7 +317503,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1717213956}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -317924,7 +318730,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 0
-  m_TargetGraphic: {fileID: 1723951783}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -318111,7 +318917,7 @@ RectTransform:
   m_Father: {fileID: 1388879801}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.7209997, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -319639,10 +320445,10 @@ RectTransform:
   - {fileID: 778487090}
   m_Father: {fileID: 36038276}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1616.2236, y: -25}
+  m_SizeDelta: {x: 453.20676, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1732295448
 MonoBehaviour:
@@ -328682,6 +329488,134 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d4a2016d9de9a64f8b0d17e9141314a, type: 3}
+--- !u!1001 &1784663543
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5352894}
+    m_Modifications:
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_text
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5797591416764135029, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+      propertyPath: m_Name
+      value: Preset Toggle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+--- !u!224 &1784663544 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2052819761972366450, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 1784663543}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1784663545 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2541537366687860817, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 1784663543}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &1784663546 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9174249313873004265, guid: 19b4d5992bd086444b642f468b61a2d6, type: 3}
+  m_PrefabInstance: {fileID: 1784663543}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1784911301
 GameObject:
   m_ObjectHideFlags: 0
@@ -331222,7 +332156,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1797919981}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -341884,10 +342818,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 473176546}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 921.4135, y: -15.005}
+  m_SizeDelta: {x: 1842.827, y: 30.01}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1843378164
 CanvasRenderer:
@@ -342761,6 +343695,17 @@ MonoBehaviour:
   rename5: {fileID: 1490554157}
   permanentSidePanel: {fileID: 1389767736}
   temporarySidePanel: {fileID: 1573630062}
+  settingsPresetToggle1: {fileID: 115361465}
+  settingsPresetToggle2: {fileID: 1784663546}
+  settingsPresetToggle3: {fileID: 793060229}
+  settingsPresetToggle4: {fileID: 512951438}
+  settingsPresetToggle5: {fileID: 29212114}
+  settingsPresetToggleText1: {fileID: 115361464}
+  settingsPresetToggleText2: {fileID: 1784663545}
+  settingsPresetToggleText3: {fileID: 793060228}
+  settingsPresetToggleText4: {fileID: 512951437}
+  settingsPresetToggleText5: {fileID: 29212113}
+  settingsPresetFeedbackText: {fileID: 610669683}
   botsPresetAutomation: {fileID: 1209963592}
   researchPresetAutomation: {fileID: 395573139}
   botsBottomBarTabButton: {fileID: 2062416496}
@@ -348939,7 +349884,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1892520715}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -351348,7 +352293,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1905331829}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -357440,10 +358385,10 @@ RectTransform:
   - {fileID: 717653381}
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -435.03}
+  m_SizeDelta: {x: 1842.827, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1941769413
 MonoBehaviour:
@@ -378928,7 +379873,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1041713014}
+  m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 818270569}
   m_HandleRect: {fileID: 1041713011}
   m_Direction: 0
@@ -380177,7 +381122,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 2067238871}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
@@ -385675,10 +386620,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1175548420}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 931.4135, y: -595.04}
+  m_SizeDelta: {x: 1842.827, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2092231247
 MonoBehaviour:
@@ -398060,7 +399005,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 2112320395}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
+++ b/Assets/Scripts/User Interface/SkillTreeSettingsManager.cs
@@ -23,6 +23,14 @@ using static Expansion.Oracle;
 /// - <see cref="OnEnable"/> / <see cref="OnDisable"/>: registers/unregisters event and UI bindings.
 /// - Toggle callbacks (side panel + automation), clipboard handlers, and tab button listeners.
 ///
+/// Owns:
+/// - Wiring of settings preset controls (buttons, toggles, labels, and clipboard path).
+/// - Runtime preset selection routing for permanent side panel, temporary side panel, and settings preset toggles.
+/// - Text sync for preset labels and user-facing feedback messages.
+/// Delegates to:
+/// - <c>Oracle</c> for load/save + skill-auto-assignment list persistence.
+/// - <c>SkillTreeManager</c> and <c>GameManager</c> for reset + re-assign execution.
+///
 /// Interacts with:
 /// - Calls into: <c>Expansion.Oracle</c> (saveSettings, SaveList/LoadList, preset data), <c>SkillTreeManager</c>
 ///   (ResetSkills), <c>GameManager</c> (AutoAssignSkillsInvoke), <c>SidePanelReferences</c> (toggle + feedback UI),
@@ -85,6 +93,19 @@ public class SkillTreeSettingsManager : MonoBehaviour
     [SerializeField] private SidePanelReferences permanentSidePanel;
     [SerializeField] private SidePanelReferences temporarySidePanel;
 
+    [Header("Skill Tree Settings Preset Toggles")]
+    [SerializeField] private Toggle settingsPresetToggle1;
+    [SerializeField] private Toggle settingsPresetToggle2;
+    [SerializeField] private Toggle settingsPresetToggle3;
+    [SerializeField] private Toggle settingsPresetToggle4;
+    [SerializeField] private Toggle settingsPresetToggle5;
+    [SerializeField] private TMP_Text settingsPresetToggleText1;
+    [SerializeField] private TMP_Text settingsPresetToggleText2;
+    [SerializeField] private TMP_Text settingsPresetToggleText3;
+    [SerializeField] private TMP_Text settingsPresetToggleText4;
+    [SerializeField] private TMP_Text settingsPresetToggleText5;
+    [SerializeField] private TMP_Text settingsPresetFeedbackText;
+
     [Header("Preset Automation (Tab Overrides)")]
     [SerializeField] private PresetAutomationReferences botsPresetAutomation;
     [SerializeField] private PresetAutomationReferences researchPresetAutomation;
@@ -95,11 +116,13 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
     private PresetToggleBindings _permanentBindings;
     private PresetToggleBindings _temporaryBindings;
+    private PresetToggleBindings _settingsPanelBindings;
     private AutomationBindings _botsAutomationBindings;
     private AutomationBindings _researchAutomationBindings;
     private bool _suppressToggleCallbacks;
     private Coroutine _permanentFeedbackRoutine;
     private Coroutine _temporaryFeedbackRoutine;
+    private Coroutine _settingsFeedbackRoutine;
     private Coroutine _feedbackRoutine;
     private Coroutine _presetInitRoutine;
     private Coroutine _toggleBindingInitRoutine;
@@ -156,9 +179,15 @@ public class SkillTreeSettingsManager : MonoBehaviour
         }
         UnregisterPresetToggleBindings(ref _permanentBindings);
         UnregisterPresetToggleBindings(ref _temporaryBindings);
+        UnregisterPresetToggleBindings(ref _settingsPanelBindings);
         UnregisterAutomationBindings(ref _botsAutomationBindings);
         UnregisterAutomationBindings(ref _researchAutomationBindings);
         UnregisterTabButtonBindings();
+        if (_settingsFeedbackRoutine != null)
+        {
+            StopCoroutine(_settingsFeedbackRoutine);
+            _settingsFeedbackRoutine = null;
+        }
         if (_toggleBindingInitRoutine != null)
         {
             StopCoroutine(_toggleBindingInitRoutine);
@@ -204,6 +233,10 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
         RegisterPresetToggleBindings(permanentSidePanel, ref _permanentBindings);
         RegisterPresetToggleBindings(temporarySidePanel, ref _temporaryBindings);
+        RegisterPresetToggleBindings(settingsPresetToggle1, settingsPresetToggle2, settingsPresetToggle3,
+            settingsPresetToggle4, settingsPresetToggle5,
+            settingsPresetToggleText1, settingsPresetToggleText2, settingsPresetToggleText3, settingsPresetToggleText4,
+            settingsPresetToggleText5, settingsPresetFeedbackText, ref _settingsPanelBindings);
         UpdateSidePanelPresetLabels();
 
         RegisterAutomationBindings(
@@ -424,6 +457,36 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
         Toggle[] toggles = GetPresetToggles(panel);
         TMP_Text[] texts = GetPresetTexts(panel);
+        RegisterPresetToggleBindings(toggles, texts, panel, null, ref bindings);
+    }
+
+    private void RegisterPresetToggleBindings(
+        Toggle toggle1,
+        Toggle toggle2,
+        Toggle toggle3,
+        Toggle toggle4,
+        Toggle toggle5,
+        TMP_Text text1,
+        TMP_Text text2,
+        TMP_Text text3,
+        TMP_Text text4,
+        TMP_Text text5,
+        TMP_Text feedbackText,
+        ref PresetToggleBindings bindings)
+    {
+        Toggle[] toggles = new[] { toggle1, toggle2, toggle3, toggle4, toggle5 };
+        TMP_Text[] texts = new[] { text1, text2, text3, text4, text5 };
+        RegisterPresetToggleBindings(toggles, texts, null, feedbackText, ref bindings);
+    }
+
+    private void RegisterPresetToggleBindings(
+        Toggle[] toggles,
+        TMP_Text[] texts,
+        SidePanelReferences feedbackPanel,
+        TMP_Text feedbackTextOverride,
+        ref PresetToggleBindings bindings)
+    {
+        if (toggles == null || texts == null) return;
         UnityAction<bool>[] handlers = new UnityAction<bool>[toggles.Length];
 
         for (int i = 0; i < toggles.Length; i++)
@@ -436,20 +499,20 @@ public class SkillTreeSettingsManager : MonoBehaviour
                 if (_suppressToggleCallbacks) return;
                 if (isOn)
                 {
-                    ApplyPresetSelection(panel, presetIndex, loadPreset: true);
+                    ApplyPresetSelection(toggles, texts, presetIndex, true, feedbackPanel, feedbackTextOverride);
                     return;
                 }
 
                 if (presetIndex != _currentPresetIndex) return;
                 if (AnyToggleOn(toggles)) return;
-                ReloadPresetSelection(panel, presetIndex);
+                ReloadPresetSelection(toggles, texts, presetIndex, feedbackPanel, feedbackTextOverride);
             };
             toggle.onValueChanged.AddListener(handler);
             handlers[i] = handler;
         }
 
-        bindings = new PresetToggleBindings(panel, toggles, texts, handlers);
-        SyncInitialPresetSelection(panel, toggles, texts);
+        bindings = new PresetToggleBindings(toggles, texts, handlers);
+        SyncInitialPresetSelection(toggles, texts);
     }
 
     private void UnregisterPresetToggleBindings(ref PresetToggleBindings bindings)
@@ -467,7 +530,7 @@ public class SkillTreeSettingsManager : MonoBehaviour
         bindings = null;
     }
 
-    private void SyncInitialPresetSelection(SidePanelReferences panel, Toggle[] toggles, TMP_Text[] texts)
+    private void SyncInitialPresetSelection(Toggle[] toggles, TMP_Text[] texts)
     {
         int selectedIndex = -1;
         for (int i = 0; i < toggles.Length; i++)
@@ -486,7 +549,7 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
         if (selectedIndex > 0)
         {
-            ApplyPresetSelection(panel, selectedIndex, loadPreset: false);
+            ApplyPresetSelection(toggles, texts, selectedIndex, loadPreset: false);
         }
         else
         {
@@ -494,18 +557,23 @@ public class SkillTreeSettingsManager : MonoBehaviour
         }
     }
 
-    private void ApplyPresetSelection(SidePanelReferences panel, int presetIndex, bool loadPreset)
+    private void ApplyPresetSelection(
+        Toggle[] toggles,
+        TMP_Text[] texts,
+        int presetIndex,
+        bool loadPreset,
+        SidePanelReferences feedbackPanel = null,
+        TMP_Text feedbackTextOverride = null)
     {
-        Toggle[] toggles = GetPresetToggles(panel);
-        TMP_Text[] texts = GetPresetTexts(panel);
-
+        if (toggles == null || texts == null) return;
+        int count = Mathf.Min(toggles.Length, texts.Length);
         if (loadPreset && presetIndex != _currentPresetIndex && _currentPresetIndex > 0)
         {
             oracle.SaveList(_currentPresetIndex);
         }
 
         _suppressToggleCallbacks = true;
-        for (int i = 0; i < toggles.Length; i++)
+        for (int i = 0; i < count; i++)
         {
             if (toggles[i] == null) continue;
             toggles[i].isOn = i + 1 == presetIndex;
@@ -517,7 +585,7 @@ public class SkillTreeSettingsManager : MonoBehaviour
         if (loadPreset)
         {
             LoadPreset(presetIndex);
-            ShowSidePanelFeedback(panel, BuildPresetFeedback(presetIndex, loaded: true));
+            ShowPresetSelectionFeedback(feedbackPanel, feedbackTextOverride, BuildPresetFeedback(presetIndex, loaded: true));
         }
         else
         {
@@ -527,13 +595,18 @@ public class SkillTreeSettingsManager : MonoBehaviour
         }
     }
 
-    private void ReloadPresetSelection(SidePanelReferences panel, int presetIndex)
+    private void ReloadPresetSelection(
+        Toggle[] toggles,
+        TMP_Text[] texts,
+        int presetIndex,
+        SidePanelReferences feedbackPanel = null,
+        TMP_Text feedbackTextOverride = null)
     {
-        Toggle[] toggles = GetPresetToggles(panel);
-        TMP_Text[] texts = GetPresetTexts(panel);
+        if (toggles == null || texts == null) return;
+        int count = Mathf.Min(toggles.Length, texts.Length);
 
         _suppressToggleCallbacks = true;
-        for (int i = 0; i < toggles.Length; i++)
+        for (int i = 0; i < count; i++)
         {
             if (toggles[i] == null) continue;
             toggles[i].isOn = i + 1 == presetIndex;
@@ -542,7 +615,7 @@ public class SkillTreeSettingsManager : MonoBehaviour
 
         UpdatePresetTextVisibility(texts, presetIndex);
         LoadPreset(presetIndex);
-        ShowSidePanelFeedback(panel, BuildPresetFeedback(presetIndex, loaded: false));
+        ShowPresetSelectionFeedback(feedbackPanel, feedbackTextOverride, BuildPresetFeedback(presetIndex, loaded: false));
     }
 
     private static bool AnyToggleOn(Toggle[] toggles)
@@ -590,12 +663,37 @@ public class SkillTreeSettingsManager : MonoBehaviour
         };
     }
 
+    private Toggle[] GetSettingsPresetToggles()
+    {
+        return new[]
+        {
+            settingsPresetToggle1,
+            settingsPresetToggle2,
+            settingsPresetToggle3,
+            settingsPresetToggle4,
+            settingsPresetToggle5
+        };
+    }
+
+    private TMP_Text[] GetSettingsPresetTexts()
+    {
+        return new[]
+        {
+            settingsPresetToggleText1,
+            settingsPresetToggleText2,
+            settingsPresetToggleText3,
+            settingsPresetToggleText4,
+            settingsPresetToggleText5
+        };
+    }
+
     private void UpdateSidePanelPresetLabels()
     {
         if (!TryGetSaveData(out DysonVerseSaveData saveData)) return;
 
         UpdateSidePanelPresetLabels(permanentSidePanel, saveData);
         UpdateSidePanelPresetLabels(temporarySidePanel, saveData);
+        UpdateSidePanelPresetLabels(GetSettingsPresetToggles(), GetSettingsPresetTexts(), saveData);
     }
 
     private void UpdateAutomationPresetLabels(DysonVerseSaveData saveData)
@@ -635,6 +733,19 @@ public class SkillTreeSettingsManager : MonoBehaviour
         for (int i = 0; i < textObjects.Length; i++)
         {
             TMP_Text text = textObjects[i];
+            if (text == null) continue;
+            text.text = GetPresetShortLabel(saveData, i + 1);
+        }
+    }
+
+    private static void UpdateSidePanelPresetLabels(Toggle[] toggles, TMP_Text[] texts, DysonVerseSaveData saveData)
+    {
+        if (texts == null || saveData == null) return;
+
+        int textCount = Mathf.Min(toggles != null ? toggles.Length : 0, texts.Length);
+        for (int i = 0; i < textCount; i++)
+        {
+            TMP_Text text = texts[i];
             if (text == null) continue;
             text.text = GetPresetShortLabel(saveData, i + 1);
         }
@@ -746,17 +857,22 @@ public class SkillTreeSettingsManager : MonoBehaviour
     {
         SyncSidePanelToPreset(permanentSidePanel, presetIndex);
         SyncSidePanelToPreset(temporarySidePanel, presetIndex);
+        SyncSidePanelToPreset(GetSettingsPresetToggles(), GetSettingsPresetTexts(), presetIndex);
     }
 
     private void SyncSidePanelToPreset(SidePanelReferences panel, int presetIndex)
     {
         if (panel == null) return;
+        SyncSidePanelToPreset(GetPresetToggles(panel), GetPresetTexts(panel), presetIndex);
+    }
 
-        Toggle[] toggles = GetPresetToggles(panel);
-        TMP_Text[] texts = GetPresetTexts(panel);
+    private void SyncSidePanelToPreset(Toggle[] toggles, TMP_Text[] texts, int presetIndex)
+    {
+        if (toggles == null || texts == null) return;
+        int count = Mathf.Min(toggles.Length, texts.Length);
 
         _suppressToggleCallbacks = true;
-        for (int i = 0; i < toggles.Length; i++)
+        for (int i = 0; i < count; i++)
         {
             if (toggles[i] == null) continue;
             toggles[i].isOn = i + 1 == presetIndex;
@@ -778,18 +894,15 @@ public class SkillTreeSettingsManager : MonoBehaviour
     private sealed class PresetToggleBindings
     {
         public PresetToggleBindings(
-            SidePanelReferences panel,
             Toggle[] toggles,
             TMP_Text[] texts,
             UnityAction<bool>[] handlers)
         {
-            Panel = panel;
             Toggles = toggles;
             Texts = texts;
             Handlers = handlers;
         }
 
-        public SidePanelReferences Panel { get; }
         public Toggle[] Toggles { get; }
         public TMP_Text[] Texts { get; }
         public UnityAction<bool>[] Handlers { get; }
@@ -913,8 +1026,9 @@ public class SkillTreeSettingsManager : MonoBehaviour
         LoadPreset(targetPreset);
 
         string name = GetPresetDisplayName(saveData, targetPreset);
-        ShowSidePanelFeedback(permanentSidePanel, $"{name} Loaded");
-        ShowSidePanelFeedback(temporarySidePanel, $"{name} Loaded");
+        ShowPresetSelectionFeedback(permanentSidePanel, null, $"{name} Loaded");
+        ShowPresetSelectionFeedback(temporarySidePanel, null, $"{name} Loaded");
+        ShowPresetSelectionFeedback(null, settingsPresetFeedbackText, $"{name} Loaded");
     }
 
     private void RegisterTabButtonBindings()
@@ -1031,11 +1145,34 @@ public class SkillTreeSettingsManager : MonoBehaviour
         }
     }
 
+    private void ShowPresetSelectionFeedback(SidePanelReferences panel, TMP_Text feedbackTextOverride, string baseText)
+    {
+        if (feedbackTextOverride != null)
+        {
+            if (_settingsFeedbackRoutine != null)
+            {
+                StopCoroutine(_settingsFeedbackRoutine);
+            }
+
+            _settingsFeedbackRoutine = StartCoroutine(PlaySidePanelFeedback(feedbackTextOverride, baseText));
+            return;
+        }
+
+        ShowSidePanelFeedback(panel, baseText);
+    }
+
     private void ShowSidePanelFeedback(SidePanelReferences panel, string baseText)
     {
         if (panel == null || panel.skillsPresetFeedbackText == null) return;
 
-        Coroutine routine = panel == permanentSidePanel ? _permanentFeedbackRoutine : _temporaryFeedbackRoutine;
+        Coroutine routine;
+        if (panel == permanentSidePanel)
+            routine = _permanentFeedbackRoutine;
+        else if (panel == temporarySidePanel)
+            routine = _temporaryFeedbackRoutine;
+        else
+            routine = null;
+
         if (routine != null)
         {
             StopCoroutine(routine);

--- a/Documentation/Code/SkillTreeSettingsManager.md
+++ b/Documentation/Code/SkillTreeSettingsManager.md
@@ -1,67 +1,115 @@
 # SkillTreeSettingsManager
 
-## Purpose
-- Owns the Skills preset UX in the Skill Tree Settings UI:
+## Purpose and scope
+- Owns the Skill Tree Settings preset UX.
+- Manages:
   - Preset naming
-  - Clipboard import/export
-  - Side panel preset toggles (5 slots) switching
-  - Tab "preset automation" overrides for Bots/Research (5 slots + Off), which auto-switch presets when those tabs are opened
+  - Clipboard export/import
+  - Preset toggle binding in:
+    - permanent side panel (`SidePanelReferences`)
+    - temporary side panel (`SidePanelReferences`)
+    - settings window (`settingsPresetToggle*` / `settingsPresetToggleText*`)
+  - Bots/Research preset automation overrides and tab-open preset application
 
-## Runtime Context
-- Runtime MonoBehaviour.
-- Intended to remain enabled so it can:
-  - react to save data becoming available
-  - keep preset labels in sync with renamed presets
-  - listen for tab button clicks and apply preset automation
+## Runtime context / entry points
+- Runtime `MonoBehaviour` tied to the Skill Tree settings UI.
+- Lifecycle:
+  - `Start()`
+  - `OnEnable()/OnDisable()`
+  - `HandleUpdateSkills()`
+- Preset switching is user-driven through:
+  - side-panel toggles
+  - settings-window toggles
+  - tab-open automation handlers
+- Export/import and rename controls are wired from Inspector button/field references.
 
-## Key Data
-- Current preset slot: `DysonVerseSaveData.selectedPreset` (1-5).
-- Preset names: `DysonVerseSaveData.preset1Name..preset5Name`.
-- Tab preset automation preferences (persist/export/import with save):
-  - `Oracle.SaveDataSettings.botsTabPresetOverride` (0=Off, 1-5)
-  - `Oracle.SaveDataSettings.researchTabPresetOverride` (0=Off, 1-5)
+## Interacts with
+- Calls:
+  - `Expansion.Oracle`
+  - `SkillTreeManager`
+  - `GameManager`
+  - `SidePanelReferences`
+  - `PresetAutomationReferences`
+- Called by:
+  - UI button/toggle events on settings and side panels
+  - `UpdateSkills` event (`Oracle -> UI`) and tab button clicks
 
-## Data Flow / Switching Behavior
-- Side panel preset toggles:
-  - Selecting a slot triggers a full preset switch:
-    - Save old slot (if needed)
-    - Reset/refund skill state
-    - Load new slot data into live auto-assign list
-    - Auto-assign
-  - Feedback is shown through `SidePanelReferences.skillsPresetFeedbackText` using the preset display name.
-- Tab preset automation toggles:
-  - Selecting a slot only updates the override preference (no immediate preset switching).
-  - The selected toggle hides its label text to reveal the icon (including Off).
-  - Implementation detail: automation toggle callbacks must capture a per-iteration index value (do not reference the
-    `for` loop variable directly inside the closure) or the handler can end up forcing all toggles off, which makes
-    the checkmark graphic appear "broken" even though labels update.
-- Tab open detection:
-  - Uses `SidePanelReferences.botsTabButton` / `SidePanelReferences.researchTabButton` (wired on both overlay and permanent refs).
-  - Also supports optional bottom-bar (or other) navigation buttons wired directly on `SkillTreeSettingsManager`:
-    - `botsBottomBarTabButton`
-    - `researchBottomBarTabButton`
-  - When clicked, if the override is enabled (1-5), it switches presets and shows feedback.
-- Initial screen behavior:
-  - After save/settings exist, `PlayerPrefs initialScreen` is checked:
-    - Bots: 1 or 9
-    - Research: 2
-  - If the tab has an override enabled, it applies it once on startup.
+## Data flow and behavior
+### Preset switching
+- Persistent source of truth: `DysonVerseSaveData.selectedPreset` (1-5), default 1.
+- `ApplyPresetSelection(..., loadPreset: true)` triggers:
+  - optional `oracle.SaveList(current)` when switching away
+  - callback suppression and radio-button state sync
+  - `LoadPreset` for the target slot
+  - UI label visibility sync (`selected text hidden`, others shown)
+- `LoadPreset` persists slot changes by:
+  - `SaveList(previous)` (before reset/load)
+  - `ResetSkills()`
+  - `oracle.LoadList(target)`
+  - `InvokeUpdateSkills()`
+  - `AutoAssignSkillsInvoke()`
+- `SuppressPresetSync()` remains around reset/load to avoid writing empty active state back into storage.
 
-## Performance / Pitfalls
-- Avoid duplicating `onClick` listeners:
-  - Overlay/permanent can point to the same `Button`; code dedupes registrations.
-- Preset switching mutates live auto-assign state:
-  - Keep `oracle.SuppressPresetSync()` usage intact to avoid overwriting slots during the temporary clear/load phase.
+### Preset labels
+- Side panel + temporary + settings labels all map to short labels generated from preset names.
+- Empty/default names collapse to short index labels (`1`..`5`).
 
-## Verification Checklist (Manual)
-1. With both overlay + permanent SidePanelReferences wired:
-  - Clicking Bots tab auto-switches to the configured preset override (unless Off).
-  - Clicking Research tab auto-switches similarly.
-2. Switching between overlay/permanent layouts still works:
-  - Tab auto-switch triggers regardless of which layout is currently active.
-3. Toggle UX:
-  - Selecting any automation toggle hides its label, showing the icon.
-  - Preset 1-5 labels show short labels derived from preset names.
-  - Clicking automation toggles immediately shows the checkmark on the selected toggle (no need to tab-swap).
-4. Save persistence:
-  - Export/import save retains `botsTabPresetOverride` and `researchTabPresetOverride`.
+### Clipboard share / move
+- `ExportPresetToClipboard(slot)` serializes:
+  - `version`
+  - preset name
+  - bot distribution
+  - IDs from active list for current slot, explicit slot list for others
+- `ImportPresetFromClipboard(slot)` validates JSON/version, de-dupes IDs, updates:
+  - preset name
+  - bot distribution
+  - preset ID list
+  - then reloads if importing the active slot
+
+### Preset automation
+- Persistent settings:
+  - `SaveDataSettings.botsTabPresetOverride`
+  - `SaveDataSettings.researchTabPresetOverride`
+- On tab open, handler applies override preset when enabled (1-5), otherwise no-op.
+- Feedback now routes:
+  - side panels via `SkillsPresetFeedbackText`
+  - settings window via `settingsPresetFeedbackText`
+
+## Wiring changes in this patch
+- Added serialized settings-window fields:
+  - `settingsPresetToggle1..5`
+  - `settingsPresetToggleText1..5`
+  - `settingsPresetFeedbackText`
+- Added shared binding logic that no longer requires `SidePanelReferences` for settings toggles:
+  - `RegisterPresetToggleBindings(Toggle[]... , TMP_Text[]..., TMP_Text feedbackTextOverride, ...)`
+- Added array-label/sync helpers for settings panel:
+  - `UpdateSidePanelPresetLabels(Toggle[]..., TMP_Text[]..., DysonVerseSaveData)`
+  - `SyncSidePanelToPreset(Toggle[]..., TMP_Text[]..., int)`
+
+## Save/load path trace points (relevant to this script)
+- `Oracle.SaveList(listNum)` stores `skillAutoAssignmentIds*` and `botDistPreset*` for each slot.
+- `Oracle.LoadList(listNum)` restores list + distribution into live `dysonVerseSaveData`.
+- Preset names are persisted in:
+  - `DysonVerseSaveData.preset1Name` through `preset5Name`
+- Override settings are persisted as part of `SaveDataSettings`.
+
+## Risks and observed caveats
+- `Oracle.SetPresetAutoAssignmentSkillIds()` does not schedule quick-save directly.
+- `Oracle.SaveList()` also does not schedule quick-save directly.
+- Existing behavior depends on the broader save pipeline (`SetAutoAssignmentSkillIds` and auto-save cadence) to persist changes.
+  In short: presets remain functional, but rapid forced-quit right after heavy preset edits can still be exposed to existing autosave timing.
+
+## Verification checklist
+1. Change names in settings and confirm:
+  - side panel labels
+  - temporary panel labels
+  - settings window labels
+  all reflect the new short names.
+2. Select presets from each of the three toggle groups:
+  - active state and feedback are correct
+  - data reload occurs as expected
+  - cross-group selection stays synced.
+3. Configure and trigger Bots/Research overrides from both side-tab and optional bottom-bar buttons.
+4. Export/import valid payload and invalid payload paths:
+  - valid payload imports and applies
+  - invalid JSON/version/empty buffer shows correct feedback and no mutation.


### PR DESCRIPTION
Add preset toggle/label/feedback wiring for the skill tree settings window so presets can be swapped from side-panel-like controls, and copy/paste can be used to move/share presets consistently.

- Binded settings window preset toggles and text labels to the same preset selection logic as side panel.
- Added optional feedback text route for settings-window actions.
- Kept preset label sync between side panel and settings-window toggles.
- Updated docs for runtime flow, save/load implications, and verification steps.
- Updated side-panel instructional copy to clarify swap and copy/paste behavior.

How tested: Not run (Unity/manual).