### PR TITLE
fix(ci): add security guards to Claude workflow triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,17 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event.sender.login == 'BlindsidedGames' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- **claude.yml**: Restrict `@claude` triggers to trusted collaborators (OWNER, MEMBER, COLLABORATOR, or BlindsidedGames) so untrusted commenters on public issues/PRs cannot invoke runs that consume `CLAUDE_CODE_OAUTH_TOKEN`
- **claude-code-review.yml**: Skip runs on fork PRs where `secrets.CLAUDE_CODE_OAUTH_TOKEN` is unavailable, preventing noisy workflow failures

## Test plan
- [ ] Verify workflow still triggers when you (BlindsidedGames) comment `@claude` on a PR or issue
- [ ] Verify workflow does NOT trigger when an untrusted commenter mentions `@claude`
- [ ] Verify code review workflow runs on non-fork PRs
- [ ] Verify code review workflow is skipped on fork-origin PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)