### PR TITLE
fix(ci): use event-specific author_association fields

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,17 +13,14 @@ on:
 jobs:
   claude:
     if: |
-      (
-        github.event.sender.login == 'BlindsidedGames' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      ) && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Fixes a regression from #69 where the trust gate used `github.event.comment.author_association` for all event types
- `pull_request_review` and `issues` events don't populate `event.comment`, so the association check silently failed — only the hardcoded `sender.login` match worked for those events
- Now each event type checks its own correct association field (`event.comment`, `event.review`, or `event.issue`)

## Test plan
- [ ] Verify `@claude` triggers from issue comments by OWNER/MEMBER/COLLABORATOR still work
- [ ] Verify `@claude` triggers from PR review comments still work
- [ ] Verify `@claude` triggers from PR reviews (submitted review body) still work
- [ ] Verify `@claude` in issue body/title by trusted users still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)