### PR TITLE
fix(space-age-ui): align energy section default state

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -89556,7 +89556,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &456917936
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- set  in  to start active
- keep Space Age Energy header visuals and content state aligned on first load

## Why
- the section looked expanded by default but behaved as collapsed until users toggled twice

## Testing
- Not run (Unity/manual)