### PR TITLE
fix(production): make Parallel Computation multiplicative and consistent

### DIFF
--- a/Assets/Data/Effects/effect.parallel_computation.data_centers.asset
+++ b/Assets/Data/Effects/effect.parallel_computation.data_centers.asset
@@ -15,8 +15,8 @@ MonoBehaviour:
   id: effect.parallel_computation.data_centers
   displayName: Parallel Computation
   targetStatId: Facility.DataCenter.Production
-  operation: 0
-  value: 0
+  operation: 1
+  value: 1
   perLevel: 0
   order: 50
   conditionId: 

--- a/Assets/Editor/GameDataAssetCreator.cs
+++ b/Assets/Editor/GameDataAssetCreator.cs
@@ -8,6 +8,25 @@ using Expansion;
 using Classes;
 using ResearchComponent = Research.ResearchPresenter;
 
+/*
+ * GameDataAssetCreator
+ * Purpose: Creates/refreshes data-driven ScriptableObject assets (facilities, skills, effects, research) from editor
+ * defaults and scene-linked data.
+ * Runs: Unity Editor only (MenuItem commands).
+ * Primary entry points: CreateGameDataAssets(), CreateCoreFacilitySkillEffects(), CreateCoreSkillEffects().
+ * Owns vs delegates: Owns asset creation/default wiring; delegates authoritative runtime effect math to
+ * SkillEffectCatalog and scene data sources (Oracle skill tree / research presenters).
+ *
+ * Interacts with:
+ * - Assets/Scripts/Systems/Stats/SkillEffectCatalog.cs (catalog-driven effect definitions)
+ * - Assets/Data/Skills/*.asset and Assets/Data/Effects/*.asset (generated/updated assets)
+ * - Assets/Scenes/Game.unity Oracle + research presenter components (source for id/default mapping)
+ *
+ * Change notes:
+ * - EffectSpec ids/operations/targetStatId must remain aligned with runtime resolver logic and existing save-compatible ids.
+ * - Parallel Computation defaults here must match effect.parallel_computation.data_centers asset and catalog settings.
+ * - Re-running these menu items overwrites defaults on matched assets; treat changes as data migrations.
+ */
 public static class GameDataAssetCreator
 {
     private const string DataFolder = "Assets/Data";
@@ -170,7 +189,7 @@ public static class GameDataAssetCreator
             new SkillSpec("parallelComputation", "Parallel Computation", new[]
             {
                 new EffectSpec("effect.parallel_computation.data_centers", "Parallel Computation",
-                    StatId.DataCenterProduction, StatOperation.Add, 0, 50, "servers_total_gt_1", new[] { "data_centers" })
+                    StatId.DataCenterProduction, StatOperation.Multiply, 1, 50, "servers_total_gt_1", new[] { "data_centers" })
             }),
             new SkillSpec("pocketDimensions", "Pocket Dimensions", new[]
             {

--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -28,6 +28,25 @@ using static IdleDysonSwarm.Systems.Constants.QuantumConstants;
 using UnityEditor;
 #endif
 
+/*
+ * Oracle (Core Partial)
+ * Purpose: Main game-state root that coordinates save state, debug tooling, and parity/diagnostic helpers.
+ * Runs: Runtime (MonoBehaviour in Game scene), with editor-only utilities enabled via context menus.
+ * Primary entry points in this file: DebugRunFacilityParityTests(), DebugCompareDataCenterProduction(), debug logging
+ * helpers for data-driven breakdowns.
+ * Owns vs delegates: Owns orchestration and persisted state containers; delegates production/stat formulas to
+ * ProductionSystem, FacilityRuntimeBuilder, and legacy bridge/stat calculators.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Systems/ProductionSystem.cs (authoritative runtime production behavior)
+ * - Assets/Scripts/Systems/Facilities/FacilityLegacyBridge.cs (legacy characterization runtime for parity checks)
+ * - Assets/Scripts/Systems/Stats/*.cs pipelines (data-driven stat computation and contribution breakdowns)
+ *
+ * Change notes:
+ * - Parity formulas in debug helpers must track runtime formula ordering exactly, or false-positive parity deltas appear.
+ * - Debug contribution ids/order are used for diagnosis; keep labels stable when adjusting formulas.
+ * - Changes here do not migrate saves directly but can change interpretation of existing save-state numbers.
+ */
 
 namespace Expansion
 {
@@ -661,8 +680,10 @@ private void PackSettingsFlags()
                 legacyComputed *= 1.5f;
             legacyComputed += infinityData.rudimentrySingularityProduction;
             double serversTotal = infinityData.servers[0] + infinityData.servers[1];
-            if (skillTreeData.parallelComputation && serversTotal > 1)
-                legacyComputed += 0.1f * Math.Log(serversTotal, 2);
+            double parallelMultiplier = skillTreeData.parallelComputation && serversTotal > 1
+                ? 1 + 0.1f * Math.Log(serversTotal, 2)
+                : 1;
+            legacyComputed *= parallelMultiplier;
 
             double updated = runtime.State.ProductionRate;
             double delta = updated - legacyComputed;
@@ -692,8 +713,7 @@ private void PackSettingsFlags()
                 if (skillTreeData.superchargedPower)
                     dataDrivenExpected *= 1.5f;
                 dataDrivenExpected += infinityData.rudimentrySingularityProduction;
-                if (skillTreeData.parallelComputation && serversTotal > 1)
-                    dataDrivenExpected += 0.1f * Math.Log(serversTotal, 2);
+                dataDrivenExpected *= parallelMultiplier;
             }
 
             AppendDataDrivenComparison(builder, "Data Centers", definition, dataDrivenExpected, results);

--- a/Assets/Scripts/Systems/Facilities/FacilityLegacyBridge.cs
+++ b/Assets/Scripts/Systems/Facilities/FacilityLegacyBridge.cs
@@ -3,6 +3,25 @@ using GameData;
 using Systems.Stats;
 using static Expansion.Oracle;
 
+/*
+ * FacilityLegacyBridge
+ * Purpose: Builds characterization runtimes that mirror legacy facility production formulas for parity/debug checks.
+ * Runs: Runtime debug and migration-parity tooling paths.
+ * Primary entry points: BuildAssemblyLineRuntime(), BuildAiManagerRuntime(), BuildServerRuntime(),
+ * BuildDataCenterRuntime(), BuildPlanetRuntime().
+ * Owns vs delegates: Owns legacy-style StatEffect composition; delegates stat evaluation to FacilityRuntime/StatCalculator.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Expansion/Oracle.cs (parity/debug context menu actions call these builders)
+ * - Assets/Scripts/Systems/Facilities/FacilityRuntime.cs (applies effects into a production breakdown)
+ * - Assets/Scripts/Systems/ProductionSystem.cs (runtime behavior that parity compares against)
+ *
+ * Change notes:
+ * - This file is a parity reference; production formula edits must stay synchronized with ProductionSystem and
+ *   SkillEffectCatalog dynamic values or debug deltas become misleading.
+ * - Contribution Id/SourceName/Order values are surfaced in debug breakdown output and should remain stable.
+ * - Parallel Computation is intentionally a multiplicative production contribution here to match runtime behavior.
+ */
 namespace Systems.Facilities
 {
     public static class FacilityLegacyBridge
@@ -354,8 +373,8 @@ namespace Systems.Facilities
                     Id = "skill.parallel_computation",
                     SourceName = "Parallel Computation",
                     TargetStatId = statId,
-                    Operation = StatOperation.Add,
-                    Value = 0.1f * System.Math.Log(serversTotal, 2),
+                    Operation = StatOperation.Multiply,
+                    Value = 1 + 0.1f * System.Math.Log(serversTotal, 2),
                     Order = 50,
                     ConditionId = "servers_total_gt_1"
                 });
@@ -589,4 +608,3 @@ namespace Systems.Facilities
         }
     }
 }
-

--- a/Assets/Scripts/Systems/ProductionSystem.cs
+++ b/Assets/Scripts/Systems/ProductionSystem.cs
@@ -5,6 +5,27 @@ using Systems.Stats;
 using Unity.Mathematics;
 using static Expansion.Oracle;
 
+/*
+ * ProductionSystem
+ * Purpose: Executes per-tick production for facilities, currencies, and derived progression values.
+ * Runs: Runtime gameplay tick (called each frame by GameManager and by OfflineProgressContext delegates).
+ * Primary entry points: CalculateProduction(), CalculateDataCenterProduction(), MoneyToAdd(), ScienceToAdd().
+ * Owns vs delegates: Owns production update ordering and resource accumulation; delegates stat math to
+ * FacilityRuntimeBuilder, GlobalStatPipeline, and ProductionMath.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Systems/GameManager.cs (main runtime caller)
+ * - Assets/Scripts/Systems/OfflineProgressSystem.cs (offline simulation uses produced rates)
+ * - Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs (data-driven facility production rates)
+ * - Assets/Scripts/Systems/Stats/GlobalStatPipeline.cs (global panel/science/money/shoulders rates)
+ *
+ * Change notes:
+ * - The meaning of infinityData.*Production fields is consumed by UI and offline simulation; keep naming/assignment
+ *   semantics stable when adjusting formulas.
+ * - Data center -> server production must remain strictly deltaTime-scaled in this system to avoid frame-rate
+ *   dependent gains.
+ * - Any formula changes here should be mirrored in Oracle parity/debug helpers and legacy bridge characterization.
+ */
 namespace Systems
 {
     public static class ProductionSystem
@@ -156,22 +177,12 @@ namespace Systems
         public static void CalculateDataCenterProduction(DysonVerseInfinityData infinityData, DysonVerseSkillTreeData skillTreeData,
             DysonVersePrestigeData prestigeData, PrestigePlus prestigePlus, double deltaTime)
         {
-            double serversTotal = infinityData.servers[0] + infinityData.servers[1];
-            double parallelBonus = skillTreeData.parallelComputation && serversTotal > 1
-                ? 0.1f * Math.Log(serversTotal, 2)
-                : 0;
-
             double baseProduction;
             double finalProduction;
             if (FacilityRuntimeBuilder.TryBuildRuntime("data_centers", infinityData, prestigeData, skillTreeData, prestigePlus,
                     out FacilityRuntime runtime))
             {
                 finalProduction = runtime.State.ProductionRate;
-                if (parallelBonus > 0)
-                {
-                    finalProduction -= parallelBonus;
-                }
-
                 baseProduction = finalProduction - infinityData.rudimentrySingularityProduction;
             }
             else
@@ -182,10 +193,7 @@ namespace Systems
 
             infinityData.dataCenterServerProduction = baseProduction;
             infinityData.serverProduction = finalProduction;
-
-            infinityData.servers[0] += skillTreeData.parallelComputation && serversTotal > 1
-                ? infinityData.serverProduction * deltaTime + parallelBonus
-                : infinityData.serverProduction * deltaTime;
+            infinityData.servers[0] += infinityData.serverProduction * deltaTime;
         }
 
         public static void CalculateServerProduction(DysonVerseInfinityData infinityData, DysonVerseSkillTreeData skillTreeData,
@@ -360,4 +368,3 @@ namespace Systems
 
     }
 }
-

--- a/Assets/Scripts/Systems/Stats/SkillEffectCatalog.cs
+++ b/Assets/Scripts/Systems/Stats/SkillEffectCatalog.cs
@@ -5,6 +5,26 @@ using Systems;
 using Systems.Facilities;
 using static Expansion.Oracle;
 
+/*
+ * SkillEffectCatalog
+ * Purpose: Declares canonical skill-to-effect mappings and resolves dynamic effect values used by the stat pipeline.
+ * Runs: Runtime and editor tooling (shared static catalog consumed by gameplay and asset generation paths).
+ * Primary entry points: GetAll(), TryResolveDynamicValue().
+ * Owns vs delegates: Owns effect ids/order/operations and dynamic math; delegates effect application/filtering to
+ * SkillEffectProvider and formula consumers in stat/facility pipelines.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Systems/Stats/SkillEffectProvider.cs (builds active StatEffect instances from these specs)
+ * - Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs (consumes global modifier effects)
+ * - Assets/Scripts/Systems/Facilities/FacilityLegacyBridge.cs (shared helper for pocket-dimensions formula)
+ * - Assets/Editor/GameDataAssetCreator.cs (uses catalog/spec parity for generated EffectDefinition assets)
+ *
+ * Change notes:
+ * - Changing effect id/operation/order/value can alter live balance and breakdown ordering across runtime + editor.
+ * - Parallel Computation must stay aligned with effect asset defaults and generator defaults
+ *   (effect.parallel_computation.data_centers).
+ * - Renaming ids/stat targets requires synchronized updates in effect assets, skill assets, and any debug parity math.
+ */
 namespace Systems.Stats
 {
     public readonly struct SkillEffectSpec
@@ -95,12 +115,12 @@ namespace Systems.Stats
                 {
                     if (skillTreeData == null || infinityData == null || !skillTreeData.parallelComputation)
                     {
-                        value = 0;
+                        value = 1;
                         return true;
                     }
 
                     double serversTotal = infinityData.servers[0] + infinityData.servers[1];
-                    value = serversTotal > 1 ? 0.1f * Math.Log(serversTotal, 2) : 0;
+                    value = serversTotal > 1 ? 1 + 0.1f * Math.Log(serversTotal, 2) : 1;
                     return true;
                 }
                 case "effect.pocket_dimensions.planets":
@@ -353,7 +373,7 @@ namespace Systems.Stats
                 "Rudimentary Singularity", StatId.DataCenterProduction, StatOperation.Add, 0, 40, null,
                 new[] { "data_centers" }, null));
             specs.Add(new SkillEffectSpec("parallelComputation", "effect.parallel_computation.data_centers",
-                "Parallel Computation", StatId.DataCenterProduction, StatOperation.Add, 0, 50, null,
+                "Parallel Computation", StatId.DataCenterProduction, StatOperation.Multiply, 1, 50, null,
                 new[] { "data_centers" }, null));
 
             specs.Add(new SkillEffectSpec("pocketDimensions", "effect.pocket_dimensions.planets",
@@ -1268,4 +1288,3 @@ namespace Systems.Stats
         }
     }
 }
-

--- a/Documentation/Code/ProductionSystem.md
+++ b/Documentation/Code/ProductionSystem.md
@@ -1,0 +1,35 @@
+# ProductionSystem
+
+## Purpose
+`ProductionSystem` applies per-tick production updates for facilities, currencies, panel decay, and related progression signals. It is the runtime source of truth for production accumulation order and writes rate fields consumed by UI and offline simulation.
+
+## Contract / behavior expectations
+- `CalculateProduction(...)` defines facility update ordering for each tick.
+- `CalculateDataCenterProduction(...)` writes:
+  - `infinityData.dataCenterServerProduction` = data-center production before rudimentary singularity add-on.
+  - `infinityData.serverProduction` = final runtime production from the data-center pipeline.
+  - `infinityData.servers[0] += infinityData.serverProduction * deltaTime`.
+- Parallel Computation is now fully represented inside the data-driven runtime pipeline; there is no separate post-pipeline add/subtract path in `ProductionSystem`.
+
+## Data flow
+1. `GameManager.Update()` calls `ProductionSystem.CalculateProduction(..., Time.deltaTime)`.
+2. Facility runtime builders/pipelines compute rates from current save state.
+3. `ProductionSystem` writes per-second rates and applies `* deltaTime` accumulation.
+4. `OfflineProgressSystem` consumes the same rate fields when simulating away-time.
+
+## Save/load implications
+- No save-field additions/removals.
+- Existing values are recalculated from current state each tick.
+- Behavior change affects `serverProduction` magnitude (by design) but does not require migration.
+
+## Performance pitfalls
+- Keep production methods allocation-free; they run every frame.
+- Avoid duplicate formula paths that drift from pipeline behavior.
+- Keep updates deltaTime-scaled to avoid frame-rate dependent gains.
+
+## Quick verification steps
+1. Enable Parallel Computation with `serversTotal > 1`; verify `serverProduction` already includes the multiplier.
+2. Confirm `CalculateDataCenterProduction` has no standalone additive parallel increment.
+3. Confirm offline progression uses `serverProduction * seconds` with no extra parallel term.
+4. Compare realtime and offline gains over the same simulated duration for consistency.
+5. Use Oracle parity logs to confirm expected/data-driven values remain aligned.

--- a/Documentation/Code/SkillEffectCatalog.md
+++ b/Documentation/Code/SkillEffectCatalog.md
@@ -1,0 +1,36 @@
+# SkillEffectCatalog
+
+## Purpose
+`SkillEffectCatalog` is the canonical mapping from skill ids to effect ids/stat targets plus dynamic value resolvers for formulas that depend on current run state (facility counts, timers, modifiers, etc.). It is used by runtime stat pipelines and editor asset generation flows.
+
+## Contract / behavior expectations
+- `GetAll()` returns the authoritative effect list used to seed/refresh `EffectDefinition` assets.
+- `TryResolveDynamicValue()` must return the exact runtime value for dynamic effects when an effect id is recognized.
+- Parallel Computation contract:
+  - Effect id: `effect.parallel_computation.data_centers`
+  - Operation: Multiply
+  - Runtime value: `1 + 0.1 * log2(totalServers)` when active and `totalServers > 1`; otherwise `1`.
+- Hypercube Networks remains a separate data-center modifier multiplier (`1 + 0.1 * log10(totalServers)`).
+
+## Data flow
+1. `SkillEffectProvider` iterates owned skills/effects from `GameDataRegistry`.
+2. For each effect, it calls `TryResolveDynamicValue()` when applicable.
+3. Resulting `StatEffect` entries are consumed by `StatCalculator` through facility/global pipelines.
+4. Contribution entries appear in breakdown UIs and debug reports.
+
+## Save/load implications
+- No new ids, no renamed ids, and no save-schema changes.
+- Existing saves automatically pick up formula behavior changes because values are recomputed from current state each tick.
+- Keep id stability (`effect.parallel_computation.data_centers`) to preserve compatibility with existing assets and ownership mappings.
+
+## Performance pitfalls
+- `TryResolveDynamicValue()` runs frequently; avoid allocations and expensive branching.
+- Repeated transcendental operations (`Math.Log`) are expected but should remain minimal and isolated.
+- Avoid introducing scene lookups or service calls in this resolver.
+
+## Quick verification steps
+1. Ensure effect spec for `parallelComputation` uses `StatOperation.Multiply` with default value `1`.
+2. With `serversTotal = 1`, confirm contribution is skipped/effective `x1`.
+3. With `serversTotal = 2`, confirm contribution value is `1.1`.
+4. With `serversTotal = 1024`, confirm contribution value is `2.0`.
+5. Confirm breakdown shows Parallel Computation as multiply, not additive.

--- a/ProjectSettings/GvhProjectSettings.xml
+++ b/ProjectSettings/GvhProjectSettings.xml
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <projectSettings>
   <projectSetting name="Google.IOSResolver.VerboseLoggingEnabled" value="False" />
-  <projectSetting name="Google.PackageManagerResolver.VerboseLoggingEnabled" value="False" />
-  <projectSetting name="Google.VersionHandler.VerboseLoggingEnabled" value="False" />
 </projectSettings>


### PR DESCRIPTION
## Summary
- change Parallel Computation from additive production to multiplicative production () so behavior matches its skill description
- remove special-case subtract/re-add handling in  so realtime/offline/UI all consume the same pipeline result
- align legacy parity/debug logic in  and  with multiplicative ordering
- sync data definitions by updating  asset and  defaults to multiply with default value 
- add/update required script headers and companion docs in  for  and 
- include existing  local change per request

## Testing
- Not run (Unity/manual)