### PR TITLE
feat(side-panel): track and format per-infinity offline usage stats

### DIFF
--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -2603,6 +2603,8 @@ private void PackSettingsFlags()
         [ContextMenu("DysonInfinity")]
         public void DysonInfinity()
         {
+            saveSettings.offlineTimeUsedPreviousInfinity = saveSettings.offlineTimeUsedThisInfinity;
+            saveSettings.offlineTimeUsedThisInfinity = 0;
             saveSettings.firstInfinityDone = true;
             int bankedSkills = 0;
             if (IsSkillOwned("banking")) bankedSkills++;
@@ -2642,6 +2644,8 @@ private void PackSettingsFlags()
 
         public void ManualDysonInfinity()
         {
+            saveSettings.offlineTimeUsedPreviousInfinity = saveSettings.offlineTimeUsedThisInfinity;
+            saveSettings.offlineTimeUsedThisInfinity = 0;
             saveSettings.firstInfinityDone = true;
             int bankedSkills = 0;
             if (IsSkillOwned("banking")) bankedSkills++;
@@ -2710,6 +2714,8 @@ private void PackSettingsFlags()
             prestigeData.infinityAutoResearch = saveSettings.prestigePlus.automation;
             saveSettings.lastInfinityPointsGained = 0;
             saveSettings.timeLastInfinity = 0;
+            saveSettings.offlineTimeUsedThisInfinity = 0;
+            saveSettings.offlineTimeUsedPreviousInfinity = 0;
             SetSkillTimerSeconds(infinityData, "androids", 0);
             SetSkillTimerSeconds(infinityData, "pocketAndroids", 0);
             skillTreeData.fragments = 0;
@@ -2808,6 +2814,8 @@ private void PackSettingsFlags()
             public bool skillsBuyOnTap;
 
             public double offlineTime;
+            public double offlineTimeUsedThisInfinity;
+            public double offlineTimeUsedPreviousInfinity;
             public double maxOfflineTime = 86400;
             [Space(10)] public int frameRate;
             [Space(10)] public bool botsButtonToggle;

--- a/Assets/Scripts/Systems/GameManager.cs
+++ b/Assets/Scripts/Systems/GameManager.cs
@@ -31,6 +31,16 @@ using static Expansion.Oracle;
 /// - Public events (UpdateSkills/AssignSkills) are cross-script contracts; changing signatures/names requires subscriber updates.
 /// - Public methods used by UI/events (for example SetSkillsReferences) must keep behavior compatible with callers.
 /// - Save-facing keys/data paths are owned by Oracle/save models; changing accessed fields requires coordinated migration updates.
+/// - Side-panel run-info lines include offline spend counters sourced from
+///   <see cref="Expansion.Oracle.SaveDataSettings.offlineTimeUsedThisInfinity"/> and
+///   <see cref="Expansion.Oracle.SaveDataSettings.offlineTimeUsedPreviousInfinity"/> rendered on a separate line
+///   in short time form.
+/// - Timer value strings should pass <c>colourOverride</c> into <see cref="CalcUtils.FormatTime"/> rather than wrapping
+///   the full output in a color tag, so unit suffixes remain uncolored.
+/// - Stats ordering/section headers in <c>skillTimersDisplayText</c> are a UX contract:
+///   bold General metrics, then bold Infinity section, then bold Skills section.
+/// - General metrics, s/IP, and Run/Offline Current/Previous rows use the same small text scale as skill detail lines.
+/// - Skill rows render at small text scale with bold skill names.
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -860,52 +870,65 @@ public class GameManager : MonoBehaviour
         /*pocketDimensionsText.text = dataCenterProductionDetailText;*/
 
         string skillTimersDisplayText = "";
+        const string halfHeightBreak = "<br><size=50%> </size><br>";
+        const string smallTextStart = "<size=80%>";
+        const string smallTextEnd = "</size>";
 
-        skillTimersDisplayText += $"Cash Multiplier: {scienceColor}{CalcUtils.FormatNumber(MoneyMultipliers())}</color>";
+        skillTimersDisplayText += "<b>General</b>";
+        skillTimersDisplayText +=
+            $"{smallTextStart}<br>Cash Multiplier: {scienceColor}{CalcUtils.FormatNumber(MoneyMultipliers())}</color>";
         skillTimersDisplayText +=
             $"<br>Research Multiplier: {scienceColor}{CalcUtils.FormatNumber(ScienceMultipliers())}</color>";
         skillTimersDisplayText +=
-            $"<br>Panel Lifetime: {scienceColor}{CalcUtils.FormatNumber(infinityData.panelLifetime)} s</color><br>";
+            $"<br>Panel Lifetime: {CalcUtils.FormatTime(infinityData.panelLifetime, shortForm: true, mspace: false, colourOverride: scienceColor)}";
 
         skillTimersDisplayText +=
-            $"<br>Current Infinity Time: {scienceColor}{CalcUtils.FormatTimeLarge(CurrentRunTime())}</color><br>";
-        if (oracle.saveSettings.timeLastInfinity > 0)
-            skillTimersDisplayText +=
-                $"Last Infinity Time: {scienceColor}{CalcUtils.FormatTimeLarge(oracle.saveSettings.timeLastInfinity)}</color><br>";
-        if (oracle.saveSettings.lastInfinityPointsGained > 0)
-        {
-            double ipPerSec = oracle.saveSettings.lastInfinityPointsGained / oracle.saveSettings.timeLastInfinity;
-            skillTimersDisplayText += ipPerSec >= 1
-                ? $"IP/s: {scienceColor}{CalcUtils.FormatNumber(ipPerSec)}</color><br>"
-                : $"s/IP: {scienceColor}{CalcUtils.FormatNumber(1 / ipPerSec)}</color><br>";
-        }
-
-        skillTimersDisplayText +=
-            $"<br>Active Panels: {scienceColor}{CalcUtils.FormatNumber(infinityData.panelsPerSec * infinityData.panelLifetime)}</color>";
+            $"{halfHeightBreak}Active Panels: {scienceColor}{CalcUtils.FormatNumber(infinityData.panelsPerSec * infinityData.panelLifetime)}</color>";
         skillTimersDisplayText +=
             $"<br>Stars Surrounded: {scienceColor}{CalcUtils.FormatNumber(StarsSurrounded(false, false))}</color>";
         skillTimersDisplayText +=
-            $"<br>Galaxies Engulfed: {scienceColor}{CalcUtils.FormatNumber(GalaxiesEngulfed(false, false))}</color><br>";
+            $"<br>Galaxies Engulfed: {scienceColor}{CalcUtils.FormatNumber(GalaxiesEngulfed(false, false))}</color>{smallTextEnd}";
+
+        double secondsPerIp = oracle.saveSettings.lastInfinityPointsGained > 0
+            ? oracle.saveSettings.timeLastInfinity / oracle.saveSettings.lastInfinityPointsGained
+            : 0;
+
+        skillTimersDisplayText += "<br><br><b>Infinity</b>";
+        skillTimersDisplayText +=
+            $"<br>{smallTextStart}s/IP: {CalcUtils.FormatTime(secondsPerIp, showDecimal: true, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}";
+        skillTimersDisplayText += $"{halfHeightBreak}{smallTextStart}<b>Run Time</b>";
+        skillTimersDisplayText +=
+            $"<br>Current: {CalcUtils.FormatTime(CurrentRunTime(), shortForm: true, mspace: false, colourOverride: scienceColor)}";
+        skillTimersDisplayText +=
+            $"<br>Previous: {CalcUtils.FormatTime(oracle.saveSettings.timeLastInfinity, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}";
+
+        skillTimersDisplayText += $"{halfHeightBreak}{smallTextStart}<b>Offline Time Used</b>";
+        skillTimersDisplayText +=
+            $"<br>Current: {CalcUtils.FormatTime(oracle.saveSettings.offlineTimeUsedThisInfinity, shortForm: true, mspace: false, colourOverride: scienceColor)}";
+        skillTimersDisplayText +=
+            $"<br>Previous: {CalcUtils.FormatTime(oracle.saveSettings.offlineTimeUsedPreviousInfinity, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}<br>";
+
+        skillTimersDisplayText += "<br><b>Skills</b>";
 
         if (skillTreeData.androids)
         {
             double androidsTimer = GetSkillTimerSeconds(infinityData, "androids");
             skillTimersDisplayText +=
-                $"<br>Androids: {scienceColor}{CalcUtils.FormatTimeLarge(androidsTimer >= 600 ? 600 : androidsTimer)}</color><br><size=80%>Granting: {scienceColor}{CalcUtils.FormatNumber(Math.Floor(androidsTimer > 600 ? 200 : androidsTimer / 3))}s Lifetime</color>.<br></size>";
+                $"<br>{smallTextStart}<b>Androids</b>: {CalcUtils.FormatTime(androidsTimer >= 600 ? 600 : androidsTimer, shortForm: true, mspace: false, colourOverride: scienceColor)}<br>Granting: {scienceColor}{CalcUtils.FormatNumber(Math.Floor(androidsTimer > 600 ? 200 : androidsTimer / 3))}</color>s Lifetime.{smallTextEnd}";
         }
 
         if (skillTreeData.pocketAndroids)
         {
             double pocketAndroidsTimer = GetSkillTimerSeconds(infinityData, "pocketAndroids");
             skillTimersDisplayText +=
-                $"<br>Pocket Androids: {scienceColor}{CalcUtils.FormatTimeLarge(pocketAndroidsTimer >= 3600 ? 3600 : pocketAndroidsTimer)}</color><br><size=80%>Multiplying Data Center Production by: {scienceColor}{CalcUtils.FormatNumber(pocketAndroidsTimer > 3564 ? 100 : 1 + pocketAndroidsTimer / 36)}</color>.<br></size>";
+                $"<br>{smallTextStart}<b>Pocket Androids</b>: {CalcUtils.FormatTime(pocketAndroidsTimer >= 3600 ? 3600 : pocketAndroidsTimer, shortForm: true, mspace: false, colourOverride: scienceColor)}<br>Multiplying Data Center Production by: {scienceColor}{CalcUtils.FormatNumber(pocketAndroidsTimer > 3564 ? 100 : 1 + pocketAndroidsTimer / 36)}</color>.{smallTextEnd}";
         }
 
         if (skillTreeData.superRadiantScattering)
         {
             double scatteringTimer = GetSkillTimerSeconds(infinityData, "superRadiantScattering");
             skillTimersDisplayText +=
-                $"<br>Scattering: {scienceColor}{CalcUtils.FormatTimeLarge(scatteringTimer)}</color><br><size=80%>Multiplying All Production by: {scienceColor}{CalcUtils.FormatNumber(1 + 0.01f * scatteringTimer)}</color>.<br></size>";
+                $"<br>{smallTextStart}<b>Scattering</b>: {CalcUtils.FormatTime(scatteringTimer, shortForm: true, mspace: false, colourOverride: scienceColor)}<br>Multiplying All Production by: {scienceColor}{CalcUtils.FormatNumber(1 + 0.01f * scatteringTimer)}</color>.{smallTextEnd}";
         }
 
 

--- a/Assets/Scripts/Systems/OfflineTimeManager.cs
+++ b/Assets/Scripts/Systems/OfflineTimeManager.cs
@@ -20,16 +20,20 @@ using static Expansion.Oracle;
 /// Primary entry points:
 /// - <see cref="Start"/>: Initializes button wiring and max values.
 /// - <see cref="SpendTime"/> / <see cref="SpendAgain"/>: Confirmed spend flow from the modal.
+/// - <see cref="SpendOfflineTime(double)"/>: Side-panel quick-spend flow.
 /// - <see cref="SetTimeDisplay"/>: Refreshes availability/interactability state.
 ///
 /// Interacts with:
 /// - Calls: <see cref="GameManager.RunAwayTime(double)"/> to apply spent time.
-/// - Reads/writes: <see cref="Expansion.Oracle.SaveDataSettings.offlineTime"/> and max values.
+/// - Reads/writes: <see cref="Expansion.Oracle.SaveDataSettings.offlineTime"/>, max values, and
+///   per-infinity offline spend counters.
 /// - Called by: UI Button/Slider events from offline-time modal and side-panel quick-spend buttons via
 ///   <see cref="SidePanelReferences"/>.
 ///
 /// Change notes:
 /// - Changing spend behavior or caps impacts all offline-time entry points (modal, spend-again, and side-panel quick buttons).
+/// - <see cref="TrySpendOfflineTime(double, out double)"/> is the single accounting path; keep all callers routed
+///   through it so offline spend counters stay accurate.
 /// - Renaming serialized fields requires re-wiring scene/prefab references, including both overlay and permanent panel refs.
 /// - If this component is hosted outside the offline-time modal, <see cref="_offlineTimeWindowRoot"/> should point at
 ///   the modal root so spend actions hide the window without disabling this manager.
@@ -134,11 +138,15 @@ public class OfflineTimeManager : MonoBehaviour
         }
 
         HideOfflineTimeWindow();
-        _gameManager.RunAwayTime(timeSlider.value > ss.offlineTime ? ss.offlineTime : timeSlider.value);
-        ss.offlineTime -= timeSlider.value > ss.offlineTime ? ss.offlineTime : timeSlider.value;
-        spendAgain.SetActive(timeSlider.value < ss.offlineTime);
-        spendAgainButtonText.text = CalcUtils.FormatTimeLarge(timeSlider.value);
-        sliderText.text = CalcUtils.FormatTimeLarge(timeSlider.value);
+        if (!TrySpendOfflineTime(timeSlider.value, out double spentSeconds))
+        {
+            doubleTap = false;
+            return;
+        }
+
+        spendAgain.SetActive(spentSeconds < ss.offlineTime);
+        spendAgainButtonText.text = CalcUtils.FormatTimeLarge(spentSeconds);
+        sliderText.text = CalcUtils.FormatTimeLarge(spentSeconds);
         doubleTap = false;
     }
 
@@ -146,11 +154,15 @@ public class OfflineTimeManager : MonoBehaviour
     {
         if (!HasSaveSettings()) return;
         HideOfflineTimeWindow();
-        _gameManager.RunAwayTime(timeSlider.value > ss.offlineTime ? ss.offlineTime : timeSlider.value);
-        ss.offlineTime -= timeSlider.value > ss.offlineTime ? ss.offlineTime : timeSlider.value;
-        spendAgain.SetActive(timeSlider.value < ss.offlineTime);
-        spendAgainButtonText.text = CalcUtils.FormatTimeLarge(timeSlider.value);
-        sliderText.text = CalcUtils.FormatTimeLarge(timeSlider.value);
+        if (!TrySpendOfflineTime(timeSlider.value, out double spentSeconds))
+        {
+            doubleTap = false;
+            return;
+        }
+
+        spendAgain.SetActive(spentSeconds < ss.offlineTime);
+        spendAgainButtonText.text = CalcUtils.FormatTimeLarge(spentSeconds);
+        sliderText.text = CalcUtils.FormatTimeLarge(spentSeconds);
         doubleTap = false;
     }
 
@@ -207,15 +219,25 @@ public class OfflineTimeManager : MonoBehaviour
     private void SpendOfflineTime(double requestedSeconds)
     {
         if (!HasSaveSettings()) return;
-        if (requestedSeconds <= 0 || ss.offlineTime < requestedSeconds) return;
-
-        _gameManager.RunAwayTime(requestedSeconds);
-        ss.offlineTime -= requestedSeconds;
+        if (!TrySpendOfflineTime(requestedSeconds, out _)) return;
 
         SetTimeDisplay();
         SetSliderMaxToAll();
         SetDoublerActive();
         doubleTap = false;
+    }
+
+    private bool TrySpendOfflineTime(double requestedSeconds, out double spentSeconds)
+    {
+        spentSeconds = 0;
+        if (!HasSaveSettings()) return false;
+        if (requestedSeconds <= 0 || ss.offlineTime <= 0) return false;
+
+        spentSeconds = Math.Min(requestedSeconds, ss.offlineTime);
+        _gameManager.RunAwayTime(spentSeconds);
+        ss.offlineTime -= spentSeconds;
+        ss.offlineTimeUsedThisInfinity += spentSeconds;
+        return true;
     }
 
     private void SetQuickButtonsInteractable()

--- a/Documentation/Code/GameManager.md
+++ b/Documentation/Code/GameManager.md
@@ -23,6 +23,24 @@
   - Writes computed values into scene TMP labels (cash/science, per-second rates, bot/panel stats, timers).
 - Side panel swapping:
   - `SidePanelController` passes `SidePanelReferences` into `SetSkillsReferences` so skill UI links remain valid.
+- Side-panel run info:
+  - `UpdateTextFields()` assembles `skillTimersDisplayText` for the blue bottom stats block.
+  - Includes current/last infinity timing, IP rate, offline-spend counters, panel/stellar progression, and skill timers.
+  - Section order:
+    - Bold `General` section (`Cash Multiplier`, `Research Multiplier`, `Panel Lifetime`, then `Active Panels`, `Stars Surrounded`, `Galaxies Engulfed`)
+    - Bold `Infinity` section with `s/IP`, `Run Time` (`Current`/`Previous`), and `Offline Time Used` (`Current`/`Previous`)
+    - Bold `Skills` section for skill timers/effects
+  - Uses a half-height spacer (`<br><size=50%> </size><br>`) between selected subsection transitions
+    (for example `Panel Lifetime -> Active Panels`, `s/IP -> Run Time`, `Run Time -> Offline Time Used`).
+  - Infinity/offline source fields:
+    - `oracle.saveSettings.offlineTimeUsedThisInfinity`
+    - `oracle.saveSettings.offlineTimeUsedPreviousInfinity`
+  - Timer labels (panel lifetime, current/last infinity, offline usage, skill timers) render with `CalcUtils.FormatTime(...)`
+    and pass `colourOverride` into the method so numeric values are colored but unit suffixes (`d/h/m/s`) are not.
+  - General metrics, `s/IP`, and `Current`/`Previous` rows under `Run Time` and `Offline Time Used`
+    are rendered at small text size (`<size=80%>`).
+  - Skill rows are rendered at small text size with bold skill names.
+  - `s/IP` is rendered with `showDecimal: true` to preserve sub-second precision.
 
 ## Save / Load Implications
 - Mutates values in save-backed structures through `Oracle` references, so runtime changes persist into future saves.
@@ -42,3 +60,6 @@
    - science per second
    - total bots
 3. Verify values still increment correctly over time and no TMP rich-text warnings/errors appear in console.
+4. Spend offline time and confirm the blue side-panel run-info block updates:
+   - `Offline Time Used (This Infinity)` increases by spent seconds.
+   - `Offline Time Used (Previous Infinity)` remains unchanged until the next Infinity reset.

--- a/Documentation/Code/OfflineTimeManager.md
+++ b/Documentation/Code/OfflineTimeManager.md
@@ -1,0 +1,47 @@
+# OfflineTimeManager
+
+## Purpose
+`OfflineTimeManager` owns the runtime UI flow for spending stored offline time from both:
+- the offline-time modal (`SpendTime`, `SpendAgain`), and
+- side-panel quick-spend buttons (2m/10m/1h).
+
+It is also the single accounting path for per-infinity offline usage tracking.
+
+## Contract / Behavior Expectations
+- All spend paths must route through `TrySpendOfflineTime(double requestedSeconds, out double spentSeconds)`.
+- Spend behavior is clamp-based:
+  - spends `min(requestedSeconds, saveSettings.offlineTime)`.
+- A successful spend must:
+  - call `GameManager.RunAwayTime(spentSeconds)`,
+  - decrement `saveSettings.offlineTime` by `spentSeconds`,
+  - increment `saveSettings.offlineTimeUsedThisInfinity` by `spentSeconds`.
+- Quick button interactability must reflect current available `offlineTime`.
+- Modal double-tap confirmation behavior remains unchanged.
+
+## Data Flow
+- Inputs:
+  - `Oracle.saveSettings.offlineTime`, `maxOfflineTime`
+  - slider/button UI events
+- Outputs:
+  - spend side effects on save data
+  - run-away simulation via `GameManager`
+  - updated UI state (buttons, slider, displayed amounts)
+
+## Save / Load Implications
+- Writes directly to save-backed `SaveDataSettings` fields:
+  - `offlineTime`
+  - `offlineTimeUsedThisInfinity`
+- Counter rollover (`this` -> `previous`) is not owned here; it is owned by Infinity reset paths in `Oracle`.
+
+## Performance Notes
+- Spend logic is event-driven, not per-frame heavy.
+- `Update()` only reacts when offline time changes or modal open state transitions.
+
+## Quick Verification Steps
+1. Open the offline modal with sufficient stored time.
+2. Spend via slider confirm, then `Spend Again`, then side-panel quick buttons.
+3. Confirm each spend:
+   - reduces `offlineTime`,
+   - advances away-time simulation,
+   - increases `offlineTimeUsedThisInfinity`.
+4. Confirm quick button interactability updates as remaining offline time drops below thresholds.

--- a/Documentation/Code/Oracle.md
+++ b/Documentation/Code/Oracle.md
@@ -1,0 +1,39 @@
+# Oracle
+
+## Purpose
+`Oracle` is the save-backed runtime root for DysonVerse. It owns top-level game state, persistence integration, migrations, and reset boundaries for Infinity/Quantum flows.
+
+This document focuses on the reset and save-schema contracts relevant to offline-time usage tracking.
+
+## Contract / Behavior Expectations
+- `SaveDataSettings` now stores per-infinity offline usage counters (seconds):
+  - `offlineTimeUsedThisInfinity`
+  - `offlineTimeUsedPreviousInfinity`
+- Infinity reset boundary behavior:
+  - At the start of `DysonInfinity()` and `ManualDysonInfinity()`:
+    - `offlineTimeUsedPreviousInfinity = offlineTimeUsedThisInfinity`
+    - `offlineTimeUsedThisInfinity = 0`
+- Quantum wipe behavior:
+  - `PrestigeDoubleWiper()` clears both counters to `0`.
+
+## Data Flow
+- Counters are incremented by `OfflineTimeManager` when time is consumed.
+- `Oracle` does not increment counters during spend; it only performs rollover/reset at reset boundaries.
+- `GameManager` reads both counters to render side-panel run-info text.
+
+## Save / Load Implications
+- New counters are additive `double` fields in `SaveDataSettings`.
+- Existing saves without these fields deserialize to default `0`, so no migration version bump is required.
+- Export/import and canonical save persistence include these fields as part of the standard save payload.
+
+## Compatibility Risks
+- Moving rollover logic out of `DysonInfinity()`/`ManualDysonInfinity()` will desync “previous infinity” display semantics.
+- Clearing only one counter in `PrestigeDoubleWiper()` creates stale values after quantum wipe.
+
+## Quick Verification Steps
+1. Spend offline time in a run and note `offlineTimeUsedThisInfinity`.
+2. Trigger Infinity:
+   - verify `this` resets to `0`,
+   - verify `previous` equals prior run’s `this`.
+3. Trigger quantum wipe path (`PrestigeDoubleWiper()`):
+   - verify both counters reset to `0`.


### PR DESCRIPTION
## Summary\n- add save-backed offline usage counters for this/previous infinity\n- roll counters on Infinity and clear on Prestige Double Wiper\n- centralize offline spend accounting so modal + quick-spend paths all increment the counter\n- refresh side-panel stats layout (General / Infinity / Skills) with multiline run/offline sections and refined text sizing/spacing\n\n## Why\n- surface meaningful offline usage stats in the side panel\n- keep accounting consistent across all spend entry points\n- improve readability and hierarchy of the stats block\n\n## Testing\n- Not run (Unity/manual).\n\n## Notes\n- commit intentionally includes only task-related files/hunks; unrelated working-tree changes were left out.