### PR TITLE
fix(save): restore lifecycle seam refactor and production UI parity suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ If multiple interpretations are plausible, enumerate the competing interpretatio
 - `Assets/Scenes/` game scenes (e.g., `Load.unity`, `Game.unity`).
 - `Assets/Scripts/` gameplay and UI code.
   - `Assets/Scripts/Systems/` core gameplay systems, stats, facilities, migrations, platform, audio.
+    - `Assets/Scripts/Systems/Save/` canonical save pipeline, lifecycle/offline-time seams (`IClock`, `ISaveStore`, `ILifecycleEvents`), recovery helpers.
   - `Assets/Scripts/Services/` service layer + service locator.
   - `Assets/Scripts/Data/` ScriptableObject definitions, IDs, and condition system.
   - `Assets/Scripts/Buildings/` building logic and presenters.
@@ -65,6 +66,7 @@ If multiple interpretations are plausible, enumerate the competing interpretatio
 - Primary source code lives in `Assets/Scripts/` and `Assets/Editor/`.
 - Avoid modifying third-party code under `Assets/Plugins/` unless explicitly requested.
 - Console log buffer lives in `Assets/Editor/ConsoleLogBuffer.cs` and writes filtered logs to `Documentation/Console/editor-console.json`. Filters/clear: `Tools/Console Log Buffer/...`.
+- Offline progression lifecycle routing now flows through `Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs` + `Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs`; keep `Documentation/Code/OfflineProgressExecutionMap.md` updated when this wiring changes.
 
 ## Documentation maintenance (required)
 When editing any script (C# under `Assets/Scripts/**` or `Assets/Editor/**`, plus any build/tooling scripts in-repo), do a documentation pass as part of the same change.

--- a/Assets/Editor/Tests/Investigations.meta
+++ b/Assets/Editor/Tests/Investigations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6af716d58c4b4e82acfd45ebe7c92a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs
+++ b/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using Systems;
+using static Expansion.Oracle;
+
+/*
+ * ProductionUiMismatchTests
+ * Purpose (editor tests): Diagnoses whether displayed production rate fields match actual applied per-second gains.
+ * Runs: Unity EditMode test runner (no PlayMode dependencies).
+ * Primary entry points: NUnit [Test] cases in this file.
+ * Owns vs delegates:
+ * - Owns parity assertions between UI-facing production fields and resource deltas after one production step.
+ * - Delegates production math and facility runtime effects to Systems.ProductionSystem and the GameData pipelines.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Systems/ProductionSystem.cs
+ * - Assets/Scripts/Buildings/FacilityBuildingPresenter.cs (consumes displayed fields under test)
+ * - Assets/Scripts/Buildings/BotPanelManager.cs (uses aggregate rates shown in progress bars)
+ * - Assets/Editor/Tests/Investigations/TestGameDataRegistryScope.cs
+ *
+ * Change notes:
+ * - If ProductionSystem field semantics change (e.g., displayed base vs total naming), update parity assertions.
+ * - If facility/skill/effect IDs or formulas are refactored, these tests must be updated to keep mismatch diagnosis valid.
+ * - These tests intentionally fail when a mismatch exists; converting to characterization tests would hide regressions.
+ */
+namespace Tests.Investigations
+{
+    [TestFixture]
+    public sealed class ProductionUiMismatchTests
+    {
+        private const double DeltaTimeSeconds = 1.0;
+        private const double Tolerance = 1e-9;
+
+        [Test]
+        public void DataCenters_DisplayedRate_Equals_AppliedServerGainRate()
+        {
+            using var registryScope = new TestGameDataRegistryScope();
+            DysonVerseInfinityData infinityData = CreateInfinityData();
+            DysonVerseSkillTreeData skillTreeData = new DysonVerseSkillTreeData
+            {
+                rudimentarySingularity = true
+            };
+            DysonVersePrestigeData prestigeData = new DysonVersePrestigeData();
+            PrestigePlus prestigePlus = new PrestigePlus();
+
+            infinityData.dataCenters[0] = 100;
+            infinityData.rudimentrySingularityProduction = 5;
+
+            double serversBefore = infinityData.servers[0];
+            ProductionSystem.CalculateDataCenterProduction(infinityData, skillTreeData, prestigeData, prestigePlus, DeltaTimeSeconds);
+            double appliedServerGain = infinityData.servers[0] - serversBefore;
+
+            Assert.That(appliedServerGain, Is.GreaterThan(0), "Expected data center production to add servers.");
+            Assert.That(infinityData.dataCenterServerProduction, Is.EqualTo(appliedServerGain).Within(Tolerance),
+                "Displayed data center server rate should match actual server gain per second.");
+        }
+
+        [Test]
+        public void Planets_DisplayedRate_Equals_AppliedDataCenterGainRate()
+        {
+            using var registryScope = new TestGameDataRegistryScope();
+            DysonVerseInfinityData infinityData = CreateInfinityData();
+            DysonVerseSkillTreeData skillTreeData = new DysonVerseSkillTreeData
+            {
+                pocketDimensions = true
+            };
+            DysonVersePrestigeData prestigeData = new DysonVersePrestigeData();
+
+            infinityData.planets[0] = 100;
+            infinityData.workers = 100;
+
+            double dataCentersBefore = infinityData.dataCenters[0];
+            ProductionSystem.CalculatePlanetProduction(infinityData, skillTreeData, prestigeData, DeltaTimeSeconds);
+            double appliedDataCenterGain = infinityData.dataCenters[0] - dataCentersBefore;
+
+            Assert.That(appliedDataCenterGain, Is.GreaterThan(0), "Expected planet production to add data centers.");
+            Assert.That(infinityData.planetsDataCenterProduction, Is.EqualTo(appliedDataCenterGain).Within(Tolerance),
+                "Displayed planet data center rate should match actual data center gain per second.");
+        }
+
+        [Test]
+        public void DataCenters_Control_NoRudimentary_ParityHolds()
+        {
+            using var registryScope = new TestGameDataRegistryScope();
+            DysonVerseInfinityData infinityData = CreateInfinityData();
+            DysonVerseSkillTreeData skillTreeData = new DysonVerseSkillTreeData
+            {
+                rudimentarySingularity = false
+            };
+            DysonVersePrestigeData prestigeData = new DysonVersePrestigeData();
+            PrestigePlus prestigePlus = new PrestigePlus();
+
+            infinityData.dataCenters[0] = 100;
+
+            double serversBefore = infinityData.servers[0];
+            ProductionSystem.CalculateDataCenterProduction(infinityData, skillTreeData, prestigeData, prestigePlus, DeltaTimeSeconds);
+            double appliedServerGain = infinityData.servers[0] - serversBefore;
+
+            Assert.That(appliedServerGain, Is.GreaterThan(0), "Expected control scenario to produce servers.");
+            Assert.That(infinityData.dataCenterServerProduction, Is.EqualTo(appliedServerGain).Within(Tolerance),
+                "Control scenario without rudimentary singularity should have matching displayed and applied rates.");
+        }
+
+        [Test]
+        public void Planets_Control_NoPocketDimensions_ParityHolds()
+        {
+            using var registryScope = new TestGameDataRegistryScope();
+            DysonVerseInfinityData infinityData = CreateInfinityData();
+            DysonVerseSkillTreeData skillTreeData = new DysonVerseSkillTreeData
+            {
+                pocketDimensions = false
+            };
+            DysonVersePrestigeData prestigeData = new DysonVersePrestigeData();
+
+            infinityData.planets[0] = 100;
+            infinityData.workers = 100;
+
+            double dataCentersBefore = infinityData.dataCenters[0];
+            ProductionSystem.CalculatePlanetProduction(infinityData, skillTreeData, prestigeData, DeltaTimeSeconds);
+            double appliedDataCenterGain = infinityData.dataCenters[0] - dataCentersBefore;
+
+            Assert.That(appliedDataCenterGain, Is.GreaterThan(0), "Expected control scenario to produce data centers.");
+            Assert.That(infinityData.planetsDataCenterProduction, Is.EqualTo(appliedDataCenterGain).Within(Tolerance),
+                "Control scenario without pocket dimensions should have matching displayed and applied rates.");
+        }
+
+        private static DysonVerseInfinityData CreateInfinityData()
+        {
+            var infinityData = new DysonVerseInfinityData
+            {
+                dataCenterModifier = 1,
+                planetModifier = 1,
+                panelLifetime = 10
+            };
+            return infinityData;
+        }
+    }
+}

--- a/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs.meta
+++ b/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f3c1c9d349ca463d9c98d9db193056c

--- a/Assets/Editor/Tests/Investigations/TestGameDataRegistryScope.cs
+++ b/Assets/Editor/Tests/Investigations/TestGameDataRegistryScope.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Reflection;
+using Expansion;
+using GameData;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+/*
+ * TestGameDataRegistryScope
+ * Purpose (editor tests): Provides an isolated GameDataRegistry singleton wired to real database assets.
+ * Runs: Unity EditMode test runner only.
+ * Primary entry points: constructor (setup), Dispose() (teardown/restore).
+ * Owns vs delegates:
+ * - Owns temporary registry lifecycle, singleton override, and required asset loading assertions.
+ * - Delegates production/stat behavior to runtime systems that consume GameDataRegistry.
+ *
+ * Interacts with:
+ * - Assets/Scripts/Data/GameDataRegistry.cs
+ * - Assets/Data/Databases/FacilityDatabase.asset
+ * - Assets/Data/Databases/SkillDatabase.asset
+ * - Assets/Data/Databases/EffectDatabase.asset
+ * - Assets/Data/Databases/ResearchDatabase.asset
+ * - Callers: Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs
+ *
+ * Change notes:
+ * - If GameDataRegistry.Instance changes from auto-property backing field, update reflection-based singleton set/reset.
+ * - If database asset locations move/rename, update the path constants below.
+ * - Any additional runtime database dependencies required by production pipelines must be added here.
+ */
+namespace Tests.Investigations
+{
+    internal sealed class TestGameDataRegistryScope : IDisposable
+    {
+        private const string FacilityDatabasePath = "Assets/Data/Databases/FacilityDatabase.asset";
+        private const string SkillDatabasePath = "Assets/Data/Databases/SkillDatabase.asset";
+        private const string EffectDatabasePath = "Assets/Data/Databases/EffectDatabase.asset";
+        private const string ResearchDatabasePath = "Assets/Data/Databases/ResearchDatabase.asset";
+
+        private static readonly FieldInfo InstanceBackingField = typeof(GameDataRegistry)
+            .GetField("<Instance>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic);
+
+        private readonly GameDataRegistry _previousInstance;
+        private readonly Oracle _previousOracle;
+        private GameObject _registryObject;
+        private GameObject _oracleObject;
+        private bool _disposed;
+
+        public GameDataRegistry Registry { get; private set; }
+
+        public TestGameDataRegistryScope()
+        {
+            _previousInstance = GameDataRegistry.Instance;
+            _previousOracle = Oracle.oracle;
+            SetInstance(null);
+            Oracle.oracle = null;
+
+            try
+            {
+                _oracleObject = new GameObject("TestOracleScope");
+                _oracleObject.hideFlags = HideFlags.HideAndDontSave;
+                Oracle testOracle = _oracleObject.AddComponent<Oracle>();
+                testOracle.saveSettings ??= new Oracle.SaveDataSettings();
+                // EditMode AddComponent does not guarantee Awake execution; set singleton explicitly.
+                Oracle.oracle = testOracle;
+
+                _registryObject = new GameObject("TestGameDataRegistryScope");
+                _registryObject.hideFlags = HideFlags.HideAndDontSave;
+                Registry = _registryObject.AddComponent<GameDataRegistry>();
+                Registry.facilityDatabase = LoadRequiredAsset<FacilityDatabase>(FacilityDatabasePath);
+                Registry.skillDatabase = LoadRequiredAsset<SkillDatabase>(SkillDatabasePath);
+                Registry.effectDatabase = LoadRequiredAsset<EffectDatabase>(EffectDatabasePath);
+                Registry.researchDatabase = LoadRequiredAsset<ResearchDatabase>(ResearchDatabasePath);
+                SetInstance(Registry);
+            }
+            catch
+            {
+                if (_registryObject != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(_registryObject);
+                    _registryObject = null;
+                }
+                if (_oracleObject != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(_oracleObject);
+                    _oracleObject = null;
+                }
+
+                Registry = null;
+                SetInstance(_previousInstance);
+                Oracle.oracle = _previousOracle;
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (_registryObject != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_registryObject);
+                _registryObject = null;
+            }
+            if (_oracleObject != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_oracleObject);
+                _oracleObject = null;
+            }
+
+            Registry = null;
+            SetInstance(_previousInstance);
+            Oracle.oracle = _previousOracle;
+        }
+
+        private static TAsset LoadRequiredAsset<TAsset>(string path) where TAsset : UnityEngine.Object
+        {
+            TAsset asset = AssetDatabase.LoadAssetAtPath<TAsset>(path);
+            Assert.IsNotNull(asset, $"Required test asset missing at '{path}'.");
+            return asset;
+        }
+
+        private static void SetInstance(GameDataRegistry instance)
+        {
+            Assert.IsNotNull(InstanceBackingField, "Could not find GameDataRegistry.Instance backing field.");
+            InstanceBackingField.SetValue(null, instance);
+        }
+    }
+}

--- a/Assets/Editor/Tests/Investigations/TestGameDataRegistryScope.cs.meta
+++ b/Assets/Editor/Tests/Investigations/TestGameDataRegistryScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 33415b555a88544bcbaca2a9f27dcdb9

--- a/Assets/Editor/Tests/Save/CanonicalSaveStoreTests.cs
+++ b/Assets/Editor/Tests/Save/CanonicalSaveStoreTests.cs
@@ -1,0 +1,91 @@
+using Expansion;
+using NUnit.Framework;
+using Systems.Save;
+
+/*
+ * CanonicalSaveStoreTests
+ * Purpose (editor tests): Verifies ISaveStore wrapper behavior over SaveSystem canonical encoding.
+ * Runs: Unity EditMode test runner (headless-friendly).
+ * Primary entry points: NUnit [Test] cases in this file.
+ * Owns vs delegates:
+ * - Owns assertions for round-trip persistence and latest-write-wins behavior.
+ * - Delegates codec/storage behavior to SaveSystem via an in-memory ISaveStorage double.
+ *
+ * Interacts with:
+ * - Systems.Save.CanonicalSaveStore
+ * - Systems.Save.SaveSystem / ISaveStorage
+ * - Expansion.Oracle.SaveDataSettings
+ *
+ * Change notes:
+ * - If canonical encoding or write semantics change, update both this file and SaveSystem tests together.
+ */
+namespace Tests.Save
+{
+    [TestFixture]
+    public sealed class CanonicalSaveStoreTests
+    {
+        private sealed class InMemoryStorage : ISaveStorage
+        {
+            public string DebugName => "in-memory";
+
+            public string Text { get; private set; } = string.Empty;
+
+            public bool Exists()
+            {
+                return !string.IsNullOrWhiteSpace(Text);
+            }
+
+            public bool TryReadText(out string text, out string error)
+            {
+                text = Text;
+                error = Exists() ? null : "File not found.";
+                return Exists();
+            }
+
+            public bool TryWriteTextAtomic(string text, out string error)
+            {
+                Text = text;
+                error = null;
+                return true;
+            }
+        }
+
+        [Test]
+        public void TrySaveThenTryLoad_RoundTripsCanonicalSettings()
+        {
+            var storage = new InMemoryStorage();
+            var store = new CanonicalSaveStore(new SaveSystem(storage));
+
+            var settings = new Oracle.SaveDataSettings();
+            settings.saveVersion = 11;
+            settings.dysonVerseSaveData.dysonVerseInfinityData.money = 42;
+            settings.dysonVerseSaveData.dysonVerseInfinityData.science = 99;
+
+            Assert.IsTrue(store.TrySave(settings, out SaveStringStats stats, out string saveError), saveError);
+            Assert.Greater(stats.EncodedChars, 0);
+
+            Assert.IsTrue(store.TryLoad(out Oracle.SaveDataSettings loaded, out string loadError), loadError);
+            Assert.AreEqual(11, loaded.saveVersion);
+            Assert.AreEqual(42, loaded.dysonVerseSaveData.dysonVerseInfinityData.money);
+            Assert.AreEqual(99, loaded.dysonVerseSaveData.dysonVerseInfinityData.science);
+        }
+
+        [Test]
+        public void TrySaveTwice_TryLoadReturnsLatestSnapshot()
+        {
+            var storage = new InMemoryStorage();
+            var store = new CanonicalSaveStore(new SaveSystem(storage));
+
+            var first = new Oracle.SaveDataSettings();
+            first.dysonVerseSaveData.dysonVerseInfinityData.money = 100;
+            Assert.IsTrue(store.TrySave(first, out _, out string firstSaveError), firstSaveError);
+
+            var second = new Oracle.SaveDataSettings();
+            second.dysonVerseSaveData.dysonVerseInfinityData.money = 250;
+            Assert.IsTrue(store.TrySave(second, out _, out string secondSaveError), secondSaveError);
+
+            Assert.IsTrue(store.TryLoad(out Oracle.SaveDataSettings loaded, out string loadError), loadError);
+            Assert.AreEqual(250, loaded.dysonVerseSaveData.dysonVerseInfinityData.money);
+        }
+    }
+}

--- a/Assets/Editor/Tests/Save/CanonicalSaveStoreTests.cs.meta
+++ b/Assets/Editor/Tests/Save/CanonicalSaveStoreTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbf2e417d06941cabb3c7df63fa33137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/Systems/OfflineAwayTimeCalculatorTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflineAwayTimeCalculatorTests.cs
@@ -1,0 +1,142 @@
+using System;
+using Expansion;
+using NUnit.Framework;
+using Systems.Save;
+
+/*
+ * OfflineAwayTimeCalculatorTests
+ * Purpose (editor tests): Verifies deterministic away-time source resolution and UTC delta/clamp behavior.
+ * Runs: Unity EditMode test runner (headless-friendly).
+ * Primary entry points: NUnit [Test] cases in this file.
+ * Owns vs delegates:
+ * - Owns expected behavior assertions for OfflineAwayTimeCalculator.
+ * - Delegates production logic to Systems.Save.OfflineAwayTimeCalculator with a fake IClock.
+ *
+ * Interacts with:
+ * - Systems.Save.OfflineAwayTimeCalculator
+ * - Systems.Save.IClock (FakeClock test double)
+ * - Expansion.Oracle.SaveDataSettings timestamps
+ *
+ * Change notes:
+ * - Changing timestamp source priority or UTC parsing in runtime code requires synchronized updates here.
+ */
+namespace Tests.Systems
+{
+    [TestFixture]
+    public sealed class OfflineAwayTimeCalculatorTests
+    {
+        private sealed class FakeClock : IClock
+        {
+            public DateTime UtcNow { get; set; }
+        }
+
+        [Test]
+        public void Compute_MissingQuitString_ReturnsMissingSourceAndZero()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateStarted = "2026-02-15T16:00:00Z"
+            };
+
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 16, 10, 0, DateTimeKind.Utc) };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.AreEqual(OfflineAwayTimeCalculator.AwayTimeSource.MissingQuitString, result.Source);
+            Assert.IsFalse(result.HasQuitTimestampInput);
+            Assert.AreEqual(0f, result.RawSeconds);
+            Assert.AreEqual(0f, result.ClampedSeconds);
+        }
+
+        [Test]
+        public void Compute_ValidQuitString_UsesQuitTimestamp()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateQuitString = "2026-02-15T16:00:00Z"
+            };
+
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 16, 15, 0, DateTimeKind.Utc) };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.AreEqual(OfflineAwayTimeCalculator.AwayTimeSource.QuitString, result.Source);
+            Assert.AreEqual(900f, result.ClampedSeconds, 0.001f);
+        }
+
+        [Test]
+        public void Compute_InvalidQuitString_FallsBackToDateStarted()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateQuitString = "not-a-date",
+                dateStarted = "2026-02-15T15:00:00Z"
+            };
+
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 15, 30, 0, DateTimeKind.Utc) };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.AreEqual(OfflineAwayTimeCalculator.AwayTimeSource.DateStartedFallback, result.Source);
+            Assert.AreEqual(1800f, result.ClampedSeconds, 0.001f);
+        }
+
+        [Test]
+        public void Compute_InvalidQuitAndStarted_UsesRuntimeFallback()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateQuitString = "invalid-quit",
+                dateStarted = "invalid-start"
+            };
+
+            var now = new DateTime(2026, 2, 15, 17, 0, 0, DateTimeKind.Utc);
+            var clock = new FakeClock { UtcNow = now };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.AreEqual(OfflineAwayTimeCalculator.AwayTimeSource.RuntimeUtcFallback, result.Source);
+            Assert.AreEqual(0f, result.ClampedSeconds);
+            Assert.AreEqual(now, result.ResolvedStartUtc);
+            Assert.AreEqual(now, result.NowUtc);
+        }
+
+        [Test]
+        public void Compute_OffsetTimestamp_ParsesAsUtc()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateQuitString = "2026-02-15T08:00:00-08:00"
+            };
+
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 16, 10, 0, DateTimeKind.Utc) };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.AreEqual(OfflineAwayTimeCalculator.AwayTimeSource.QuitString, result.Source);
+            Assert.AreEqual(600f, result.ClampedSeconds, 0.001f);
+        }
+
+        [Test]
+        public void Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero()
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                dateQuitString = "2026-02-15T17:00:00Z"
+            };
+
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 16, 0, 0, DateTimeKind.Utc) };
+            var calculator = new OfflineAwayTimeCalculator(clock);
+
+            OfflineAwayTimeCalculator.AwayTimeComputation result = calculator.Compute(settings);
+
+            Assert.Less(result.RawSeconds, 0f);
+            Assert.AreEqual(0f, result.ClampedSeconds);
+        }
+    }
+}

--- a/Assets/Editor/Tests/Systems/OfflineAwayTimeCalculatorTests.cs.meta
+++ b/Assets/Editor/Tests/Systems/OfflineAwayTimeCalculatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 782b421d1d2743f78137622c9888f6a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Systems.Save;
+
+/*
+ * OfflineLifecycleCoordinatorTests
+ * Purpose (editor tests): Characterizes lifecycle event routing to save/reload requests.
+ * Runs: Unity EditMode test runner (headless-friendly).
+ * Primary entry points: NUnit [Test] cases in this file.
+ * Owns vs delegates:
+ * - Owns lifecycle permutation assertions (focus/pause/quit order and callback counts).
+ * - Delegates lifecycle policy execution to Systems.Save.OfflineLifecycleCoordinator.
+ *
+ * Interacts with:
+ * - Systems.Save.ILifecycleEvents/ManualLifecycleEvents
+ * - Systems.Save.OfflineLifecycleCoordinator
+ *
+ * Change notes:
+ * - Any lifecycle policy changes in OfflineLifecycleCoordinator should update expected phase/order assertions here.
+ */
+namespace Tests.Systems
+{
+    [TestFixture]
+    public sealed class OfflineLifecycleCoordinatorTests
+    {
+        [Test]
+        public void FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent()
+        {
+            var lifecycleEvents = new ManualLifecycleEvents();
+            var savePhases = new List<string>();
+            int reloadCount = 0;
+
+            using var coordinator = new OfflineLifecycleCoordinator(
+                lifecycleEvents,
+                phase => savePhases.Add(phase),
+                () => reloadCount++,
+                reloadOnFocusGain: false);
+
+            lifecycleEvents.RaiseFocusChanged(false);
+            lifecycleEvents.RaisePauseChanged(true);
+            lifecycleEvents.RaiseQuitRequested();
+
+            CollectionAssert.AreEqual(
+                new[] { "OnApplicationFocusLost", "OnApplicationPause", "OnApplicationQuit" },
+                savePhases);
+            Assert.AreEqual(0, reloadCount);
+        }
+
+        [Test]
+        public void PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave()
+        {
+            var lifecycleEvents = new ManualLifecycleEvents();
+            var savePhases = new List<string>();
+
+            using var coordinator = new OfflineLifecycleCoordinator(
+                lifecycleEvents,
+                phase => savePhases.Add(phase),
+                () => { },
+                reloadOnFocusGain: false);
+
+            lifecycleEvents.RaisePauseChanged(true);
+            lifecycleEvents.RaisePauseChanged(false);
+            lifecycleEvents.RaiseQuitRequested();
+
+            CollectionAssert.AreEqual(
+                new[] { "OnApplicationPause", "OnApplicationQuit" },
+                savePhases);
+        }
+
+        [Test]
+        public void RapidFocusToggles_RequestsSaveOnlyOnFocusLoss()
+        {
+            var lifecycleEvents = new ManualLifecycleEvents();
+            var savePhases = new List<string>();
+            int reloadCount = 0;
+
+            using var coordinator = new OfflineLifecycleCoordinator(
+                lifecycleEvents,
+                phase => savePhases.Add(phase),
+                () => reloadCount++,
+                reloadOnFocusGain: false);
+
+            lifecycleEvents.RaiseFocusChanged(false);
+            lifecycleEvents.RaiseFocusChanged(true);
+            lifecycleEvents.RaiseFocusChanged(false);
+            lifecycleEvents.RaiseFocusChanged(true);
+
+            CollectionAssert.AreEqual(
+                new[] { "OnApplicationFocusLost", "OnApplicationFocusLost" },
+                savePhases);
+            Assert.AreEqual(0, reloadCount);
+        }
+
+        [Test]
+        public void FocusGainReloadEnabled_ReloadsOnEachFocusGain()
+        {
+            var lifecycleEvents = new ManualLifecycleEvents();
+            int saveCount = 0;
+            int reloadCount = 0;
+
+            using var coordinator = new OfflineLifecycleCoordinator(
+                lifecycleEvents,
+                _ => saveCount++,
+                () => reloadCount++,
+                reloadOnFocusGain: true);
+
+            lifecycleEvents.RaiseFocusChanged(true);
+            lifecycleEvents.RaiseFocusChanged(false);
+            lifecycleEvents.RaiseFocusChanged(true);
+
+            Assert.AreEqual(1, saveCount);
+            Assert.AreEqual(2, reloadCount);
+        }
+
+        [Test]
+        public void Dispose_UnsubscribesFromEvents()
+        {
+            var lifecycleEvents = new ManualLifecycleEvents();
+            int saveCount = 0;
+            int reloadCount = 0;
+
+            var coordinator = new OfflineLifecycleCoordinator(
+                lifecycleEvents,
+                _ => saveCount++,
+                () => reloadCount++,
+                reloadOnFocusGain: true);
+
+            coordinator.Dispose();
+
+            lifecycleEvents.RaisePauseChanged(true);
+            lifecycleEvents.RaiseFocusChanged(false);
+            lifecycleEvents.RaiseFocusChanged(true);
+            lifecycleEvents.RaiseQuitRequested();
+
+            Assert.AreEqual(0, saveCount);
+            Assert.AreEqual(0, reloadCount);
+        }
+    }
+}

--- a/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs.meta
+++ b/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb9b32d1b4564208b09f3c2204197307
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Globalization;
+using Expansion;
+using NUnit.Framework;
+using Systems;
+using Systems.Save;
+
+/*
+ * OfflinePersistenceRegressionTests
+ * Purpose (editor tests): End-to-end regression harness for mixed symptoms (rollback + missing offline time).
+ * Runs: Unity EditMode test runner (headless-friendly).
+ * Primary entry points: NUnit [TestCase] matrix over 2m/15m/60m reopen windows.
+ * Owns vs delegates:
+ * - Owns scenario orchestration (save on lifecycle event -> reopen -> compute/apply away time).
+ * - Delegates persistence encoding to CanonicalSaveStore and away/offline logic to runtime systems.
+ *
+ * Interacts with:
+ * - Systems.Save.CanonicalSaveStore / SaveSystem / OfflineAwayTimeCalculator / OfflineLifecycleCoordinator
+ * - Systems.OfflineProgressSystem
+ * - Expansion.Oracle.SaveDataSettings
+ *
+ * Change notes:
+ * - If save timestamping or away-time application changes, keep this matrix aligned to avoid silent regressions.
+ */
+namespace Tests.Systems
+{
+    [TestFixture]
+    public sealed class OfflinePersistenceRegressionTests
+    {
+        private sealed class FakeClock : IClock
+        {
+            public DateTime UtcNow { get; set; }
+        }
+
+        private sealed class InMemoryStorage : ISaveStorage
+        {
+            public string DebugName => "in-memory";
+            public string Text { get; private set; } = string.Empty;
+
+            public bool Exists()
+            {
+                return !string.IsNullOrWhiteSpace(Text);
+            }
+
+            public bool TryReadText(out string text, out string error)
+            {
+                text = Text;
+                error = Exists() ? null : "File not found.";
+                return Exists();
+            }
+
+            public bool TryWriteTextAtomic(string text, out string error)
+            {
+                Text = text;
+                error = null;
+                return true;
+            }
+        }
+
+        [TestCase(120d)]
+        [TestCase(900d)]
+        [TestCase(3600d)]
+        public void ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(double awaySeconds)
+        {
+            var storage = new InMemoryStorage();
+            var saveStore = new CanonicalSaveStore(new SaveSystem(storage));
+            var clock = new FakeClock { UtcNow = new DateTime(2026, 2, 15, 18, 0, 0, DateTimeKind.Utc) };
+            var awayCalculator = new OfflineAwayTimeCalculator(clock);
+            var lifecycleEvents = new ManualLifecycleEvents();
+
+            Oracle.SaveDataSettings current = CreateBaselineSave(clock.UtcNow);
+            current.dysonVerseSaveData.dysonVerseInfinityData.money = 150;
+
+            // Close #1: focus lost should stamp quit time and persist latest progress.
+            using var coordinator = new OfflineLifecycleCoordinator(lifecycleEvents, phase =>
+            {
+                current.dateQuitString = clock.UtcNow.ToString(CultureInfo.InvariantCulture);
+                Assert.IsTrue(saveStore.TrySave(current, out _, out string saveError), saveError);
+            }, () => { }, reloadOnFocusGain: false);
+
+            lifecycleEvents.RaiseFocusChanged(false);
+            clock.UtcNow = clock.UtcNow.AddSeconds(awaySeconds);
+
+            // Reopen #1: load and apply offline return.
+            Assert.IsTrue(saveStore.TryLoad(out current, out string firstLoadError), firstLoadError);
+            double firstAway = awayCalculator.Compute(current).ClampedSeconds;
+            OfflineProgressSystem.ApplyReturnValues(firstAway, CreateContext(current), ui: null);
+
+            Assert.AreEqual(150d, current.dysonVerseSaveData.dysonVerseInfinityData.money, 0.001d, "Latest saved progress rolled back on reopen.");
+            Assert.AreEqual(awaySeconds, current.offlineTime, 0.001d, "Offline time was not granted for first reopen.");
+
+            // Close #2 + Reopen #2: verify repeated cycles keep latest state and add offline time exactly once per close/open.
+            current.dysonVerseSaveData.dysonVerseInfinityData.money += 25d;
+            lifecycleEvents.RaisePauseChanged(true);
+            clock.UtcNow = clock.UtcNow.AddSeconds(awaySeconds / 2d);
+
+            Assert.IsTrue(saveStore.TryLoad(out current, out string secondLoadError), secondLoadError);
+            double secondAway = awayCalculator.Compute(current).ClampedSeconds;
+            OfflineProgressSystem.ApplyReturnValues(secondAway, CreateContext(current), ui: null);
+
+            Assert.AreEqual(175d, current.dysonVerseSaveData.dysonVerseInfinityData.money, 0.001d, "Second close/open lost latest saved progress.");
+            Assert.AreEqual(awaySeconds + (awaySeconds / 2d), current.offlineTime, 0.001d, "Offline time accumulation across reopen cycles was incorrect.");
+        }
+
+        private static Oracle.SaveDataSettings CreateBaselineSave(DateTime startedUtc)
+        {
+            return new Oracle.SaveDataSettings
+            {
+                dateStarted = startedUtc.ToString(CultureInfo.InvariantCulture),
+                offlineTime = 0d,
+                maxOfflineTime = 100000d
+            };
+        }
+
+        private static OfflineProgressContext CreateContext(Oracle.SaveDataSettings settings)
+        {
+            return new OfflineProgressContext
+            {
+                infinityData = settings.dysonVerseSaveData.dysonVerseInfinityData,
+                prestigeData = settings.dysonVerseSaveData.dysonVersePrestigeData,
+                skillTreeData = settings.dysonVerseSaveData.dysonVerseSkillTreeData,
+                saveSettings = settings,
+                SetBotDistribution = () => { },
+                CalculateShouldersSkills = _ => { },
+                CalculateProduction = () => { },
+                MoneyToAdd = () => 0,
+                ScienceToAdd = () => 0
+            };
+        }
+
+    }
+}

--- a/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs.meta
+++ b/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27e467a9347a4ae8991ec59e5aabed45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/Systems/OfflineProgressSystemTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflineProgressSystemTests.cs
@@ -1,0 +1,103 @@
+using Expansion;
+using NUnit.Framework;
+using Systems;
+
+/*
+ * OfflineProgressSystemTests
+ * Purpose (editor tests): Validates offline-time grant behavior in OfflineProgressSystem.ApplyReturnValues.
+ * Runs: Unity EditMode test runner (headless-friendly).
+ * Primary entry points: NUnit [Test] cases in this file.
+ * Owns vs delegates:
+ * - Owns assertions around cap handling, cheater path, and additive behavior across reopen grants.
+ * - Delegates production logic to Systems.OfflineProgressSystem with lightweight context doubles.
+ *
+ * Interacts with:
+ * - Systems.OfflineProgressSystem
+ * - Systems.OfflineProgressContext
+ * - Expansion.Oracle save data types
+ *
+ * Change notes:
+ * - If ApplyReturnValues semantics/caps change, update expected assertions and related regression docs together.
+ */
+namespace Tests.Systems
+{
+    [TestFixture]
+    public sealed class OfflineProgressSystemTests
+    {
+        [Test]
+        public void ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool()
+        {
+            OfflineProgressContext context = CreateContext(offlineTime: 30, maxOfflineTime: 600);
+
+            OfflineProgressSystem.ApplyReturnValues(awayTime: 120, context, ui: null);
+
+            Assert.AreEqual(150, context.saveSettings.offlineTime, 0.001);
+            Assert.IsFalse(context.saveSettings.cheater);
+        }
+
+        [Test]
+        public void ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool()
+        {
+            OfflineProgressContext context = CreateContext(offlineTime: 45, maxOfflineTime: 600);
+
+            OfflineProgressSystem.ApplyReturnValues(awayTime: 0, context, ui: null);
+
+            Assert.AreEqual(45, context.saveSettings.offlineTime, 0.001);
+        }
+
+        [Test]
+        public void ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime()
+        {
+            OfflineProgressContext context = CreateContext(offlineTime: 500, maxOfflineTime: 600);
+
+            OfflineProgressSystem.ApplyReturnValues(awayTime: 300, context, ui: null);
+
+            Assert.AreEqual(600, context.saveSettings.offlineTime, 0.001);
+        }
+
+        [Test]
+        public void ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime()
+        {
+            OfflineProgressContext context = CreateContext(offlineTime: 200, maxOfflineTime: 600);
+
+            OfflineProgressSystem.ApplyReturnValues(awayTime: -5, context, ui: null);
+
+            Assert.IsTrue(context.saveSettings.cheater);
+            Assert.AreEqual(0, context.saveSettings.offlineTime, 0.001);
+            Assert.AreEqual(0, context.saveSettings.maxOfflineTime, 0.001);
+        }
+
+        [Test]
+        public void ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns()
+        {
+            OfflineProgressContext context = CreateContext(offlineTime: 0, maxOfflineTime: 1000);
+
+            OfflineProgressSystem.ApplyReturnValues(awayTime: 120, context, ui: null);
+            OfflineProgressSystem.ApplyReturnValues(awayTime: 300, context, ui: null);
+
+            Assert.AreEqual(420, context.saveSettings.offlineTime, 0.001);
+        }
+
+        private static OfflineProgressContext CreateContext(double offlineTime, double maxOfflineTime)
+        {
+            var settings = new Oracle.SaveDataSettings
+            {
+                offlineTime = offlineTime,
+                maxOfflineTime = maxOfflineTime
+            };
+
+            return new OfflineProgressContext
+            {
+                infinityData = new Oracle.DysonVerseInfinityData(),
+                prestigeData = new Oracle.DysonVersePrestigeData(),
+                skillTreeData = new Oracle.DysonVerseSkillTreeData(),
+                saveSettings = settings,
+                SetBotDistribution = () => { },
+                CalculateShouldersSkills = _ => { },
+                CalculateProduction = () => { },
+                MoneyToAdd = () => 0,
+                ScienceToAdd = () => 0
+            };
+        }
+    }
+}

--- a/Assets/Editor/Tests/Systems/OfflineProgressSystemTests.cs.meta
+++ b/Assets/Editor/Tests/Systems/OfflineProgressSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2199abea8034e6797b43a41e9b0c5c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Buildings/BotPanelManager.cs
+++ b/Assets/Scripts/Buildings/BotPanelManager.cs
@@ -23,6 +23,8 @@ using static Expansion.Oracle;
 /// - Serialized references (panels, images, progress bar roots) must be wired in the relevant prefab/scene.
 /// - If you change which production rate feeds a bar, also update the matching "toggle off when not producing"
 ///   condition so bars don't appear dead.
+/// - Keep bar rates aligned with the same total applied production used by facility cards and breakdown popup
+///   (avoid manually re-adding bonus subcomponents that are already included in runtime totals).
 /// </summary>
 public class BotPanelManager : MonoBehaviour
 {
@@ -121,14 +123,14 @@ public class BotPanelManager : MonoBehaviour
         SetFacilityProgressBar(
             dataCenters,
             dataCentersProgressBarRoot,
-            infinityData.serverProduction + infinityData.rudimentrySingularityProduction,
+            infinityData.serverProduction,
             infinityData.servers[0]);
 
         // Planets → producing Data Centers
         SetFacilityProgressBar(
             planets,
             planetsProgressBarRoot,
-            infinityData.dataCenterProduction + infinityData.pocketDimensionsProduction,
+            infinityData.dataCenterProduction,
             infinityData.dataCenters[0]);
 
         // Mega-structure bars also show what each facility is producing (one tier down).

--- a/Assets/Scripts/Expansion/Oracle.Persistence.cs
+++ b/Assets/Scripts/Expansion/Oracle.Persistence.cs
@@ -24,11 +24,12 @@ namespace Expansion
     /// <para>Diagnostics: writes one tagged warning per save lifecycle event plus offline-time replay data via
     /// <see cref="AwayForSeconds"/>.</para>
     /// <para>Delegates: ES3 artifact probing to <see cref="LegacyEs3Save"/>, codec/storage to
-    /// <see cref="SaveCodec"/>/<see cref="SaveSystem"/>.</para>
+    /// <see cref="SaveCodec"/>/<see cref="SaveSystem"/>/<see cref="ISaveStore"/>.</para>
     /// Canonical persistence stores the exact same save string used by clipboard export/import (prefix <c>IDB1:</c>).
     /// <para>Codec: <see cref="SaveCodec"/>.</para>
     /// <para>Snapshot compaction: <see cref="SaveSnapshotBuilder"/>.</para>
-    /// <para>Persistence orchestration: <see cref="SaveSystem"/> + <see cref="OdinStringFileStorage"/>.</para>
+    /// <para>Persistence orchestration: <see cref="ISaveStore"/> (default: <see cref="CanonicalSaveStore"/> wrapping
+    /// <see cref="SaveSystem"/> + <see cref="OdinStringFileStorage"/>).</para>
     /// <para>Interacts with:
     /// callers include Unity lifecycle via <c>Oracle.Start()</c> and debug UI buttons; callees include
     /// <see cref="SaveLoadCandidateSelector"/>, <see cref="LegacyEs3Save"/>, and migration routines in
@@ -42,6 +43,7 @@ namespace Expansion
     {
         private void SaveInternal(bool force, bool updateQuitTime = false)
         {
+            EnsureRuntimeSeamsInitialized();
             if (!_isSaveReady && !force)
             {
                 if (updateQuitTime)
@@ -57,7 +59,7 @@ namespace Expansion
             if (updateQuitTime)
             {
                 dateSource = "updated";
-                SetDateQuitString(DateTime.UtcNow.ToString(CultureInfo.InvariantCulture), isQuitTimestamp: true);
+                SetDateQuitString(_clock.UtcNow.ToString(CultureInfo.InvariantCulture), isQuitTimestamp: true);
             }
 
             bool saved = TrySaveState(out string saveError);
@@ -225,6 +227,7 @@ namespace Expansion
 
         public bool TrySaveState(out string error)
         {
+            EnsureRuntimeSeamsInitialized();
             error = null;
             SaveDictionaries();
             PackSettingsFlags();
@@ -234,8 +237,7 @@ namespace Expansion
                 buildOwnedBitsetFromRuntime: BuildOwnedBitsetFromRuntime,
                 getAutoAssignmentSkillIds: GetAutoAssignmentSkillIds);
 
-            SaveSystem saveSystem = SaveSystem.CreateDefault();
-            if (!saveSystem.TrySave(snapshot, out _, out string saveError))
+            if (!_saveStore.TrySave(snapshot, out _, out string saveError))
             {
                 error = saveError;
                 Debug.LogError($"[Save] Failed writing canonical save file: {error}");
@@ -273,17 +275,19 @@ namespace Expansion
 
         private void ApplyLoadedSettings(SaveDataSettings loaded, string sourceLog)
         {
+            EnsureRuntimeSeamsInitialized();
             saveSettings = loaded;
             LoadDictionaries();
             if (!oracle.saveSettings.cheater && oracle.saveSettings.maxOfflineTime < 86400)
                 oracle.saveSettings.maxOfflineTime = 86400;
-            saveSettings.lastSuccessfulLoadUtc = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+            saveSettings.lastSuccessfulLoadUtc = _clock.UtcNow.ToString(CultureInfo.InvariantCulture);
             Loaded = true;
             Debug.Log($"Loaded with {sourceLog}");
         }
 
         public void Load()
         {
+            EnsureRuntimeSeamsInitialized();
             Loaded = false;
             SetSaveReady(false);
             WipeSaveData();
@@ -292,10 +296,9 @@ namespace Expansion
             // This path is intended to replace ES3 as the primary persistence mechanism, while ES3 remains
             // as a legacy import/fallback during the transition period.
             bool loadedFromCanonical = false;
-            SaveSystem saveSystem = SaveSystem.CreateDefault();
-            if (saveSystem.Storage.Exists())
+            if (_saveStore.Exists())
             {
-                if (saveSystem.TryLoad(out SaveDataSettings canonicalLoaded, out string canonicalError))
+                if (_saveStore.TryLoad(out SaveDataSettings canonicalLoaded, out string canonicalError))
                 {
                     loadedFromCanonical = true;
                     ApplyLoadedSettings(canonicalLoaded, "canonical save file");
@@ -385,7 +388,7 @@ namespace Expansion
 
             if (!Loaded)
             {
-                saveSettings.dateStarted = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+                saveSettings.dateStarted = _clock.UtcNow.ToString(CultureInfo.InvariantCulture);
                 Loaded = true;
                 Debug.Log("Made new save");
             }
@@ -433,44 +436,28 @@ namespace Expansion
 
         private void AwayForSeconds()
         {
-            if (string.IsNullOrEmpty(oracle.saveSettings.dateQuitString))
+            EnsureRuntimeSeamsInitialized();
+            OfflineAwayTimeCalculator.AwayTimeComputation computation = _awayTimeCalculator.Compute(oracle.saveSettings);
+            if (!computation.HasQuitTimestampInput)
             {
                 Debug.LogWarning($"[OfflineTimeDiag] AwayForSeconds | platform={Application.platform}, dateQuitString_missing=true");
                 return;
             }
-            DateTime dateStarted;
-            string dateSource = "quitString";
-            if (!DateTime.TryParse(oracle.saveSettings.dateQuitString, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out dateStarted))
-            {
-                dateSource = "dateStartedFallback";
-                if (!DateTime.TryParse(oracle.saveSettings.dateStarted, CultureInfo.InvariantCulture,
-                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out dateStarted))
-                {
-                    dateSource = "runtimeUtcFallback";
-                    dateStarted = DateTime.UtcNow;
-                }
-            }
 
-            DateTime dateNow = DateTime.UtcNow;
-            TimeSpan timespan = dateNow - dateStarted;
-            float seconds = (float)timespan.TotalSeconds;
-            float clampedSeconds = Math.Max(0, seconds);
             Debug.LogWarning(
                 "[OfflineTimeDiag] AwayForSeconds | " +
                     $"platform={Application.platform}, " +
-                    $"dateSource={dateSource}, " +
+                    $"dateSource={computation.SourceLabel}, " +
                 $"dateQuit='{FormatDebugString(oracle.saveSettings.dateQuitString)}', " +
                 $"dateStarted='{FormatDebugString(oracle.saveSettings.dateStarted)}', " +
-                $"resolvedStart='{FormatUtc(dateStarted)}', now='{FormatUtc(dateNow)}', " +
-                $"awayRawSeconds={seconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
-                $"awayClampedSeconds={clampedSeconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"resolvedStart='{FormatUtcForOfflineDiag(computation.ResolvedStartUtc)}', now='{FormatUtcForOfflineDiag(computation.NowUtc)}', " +
+                $"awayRawSeconds={computation.RawSeconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
+                $"awayClampedSeconds={computation.ClampedSeconds.ToString("F3", CultureInfo.InvariantCulture)}, " +
                 $"offlineTime={saveSettings.offlineTime.ToString(CultureInfo.InvariantCulture)}, " +
                 $"maxOfflineTime={saveSettings.maxOfflineTime.ToString(CultureInfo.InvariantCulture)}, " +
                 $"doubleTimeBefore={saveSettings.sdPrestige.doubleTime.ToString(CultureInfo.InvariantCulture)}");
-            if (seconds < 0) seconds = 0;
-            saveSettings.sdPrestige.doubleTime += seconds;
-            AwayFor?.Invoke(seconds);
+            saveSettings.sdPrestige.doubleTime += computation.ClampedSeconds;
+            AwayFor?.Invoke(computation.ClampedSeconds);
         }
 
         private static string FormatDebugString(string value)
@@ -478,10 +465,6 @@ namespace Expansion
             return string.IsNullOrWhiteSpace(value) ? "n/a" : value;
         }
 
-        private static string FormatUtc(DateTime value)
-        {
-            if (value == default) return "0001-01-01T00:00:00.0000000Z";
-            return value.ToString("o", CultureInfo.InvariantCulture);
-        }
+        // FormatUtcForOfflineDiag moved to Oracle.RuntimeSeams.cs so all offline/lifecycle diagnostics share one formatter.
     }
 }

--- a/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs
+++ b/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Globalization;
+using Systems.Save;
+using UnityEngine;
+
+namespace Expansion
+{
+    /*
+     * Oracle.RuntimeSeams
+     * Purpose (runtime): Centralized dependency seam initialization for time, canonical save store, and lifecycle routing.
+     * Runs: Runtime (Oracle MonoBehaviour in scene) and editor tests that exercise seam-backed helpers.
+     * Primary entry points:
+     * - EnsureRuntimeSeamsInitialized()
+     * - OnLifecycleSaveRequested(string phase)
+     * - OnLifecycleReloadRequested()
+     * Owns vs delegates:
+     * - Owns dependency wiring and lifecycle coordinator subscription.
+     * - Delegates actual persistence to Oracle.SaveForQuit()/Oracle.Load() and Systems.Save abstractions.
+     *
+     * Interacts with:
+     * - Systems.Save.IClock/SystemClock
+     * - Systems.Save.ISaveStore/CanonicalSaveStore
+     * - Systems.Save.ILifecycleEvents/OfflineLifecycleCoordinator/OfflineAwayTimeCalculator
+     * - Oracle lifecycle callbacks in Assets/Scripts/Expansion/Oracle.cs
+     *
+     * Change notes:
+     * - Lifecycle routing changes here affect save-on-background/quit behavior on all platforms.
+     * - If seam initialization order changes, ensure Oracle.Awake still initializes before any save/load callback.
+     */
+    public partial class Oracle
+    {
+        private IClock _clock;
+        private ISaveStore _saveStore;
+        private OfflineAwayTimeCalculator _awayTimeCalculator;
+        private ManualLifecycleEvents _lifecycleEvents;
+        private OfflineLifecycleCoordinator _offlineLifecycleCoordinator;
+
+        private void EnsureRuntimeSeamsInitialized()
+        {
+            _clock ??= new SystemClock();
+            _saveStore ??= CanonicalSaveStore.CreateDefault();
+            _awayTimeCalculator ??= new OfflineAwayTimeCalculator(_clock);
+
+            if (_lifecycleEvents == null)
+            {
+                _lifecycleEvents = new ManualLifecycleEvents();
+            }
+
+            if (_offlineLifecycleCoordinator == null)
+            {
+                _offlineLifecycleCoordinator = new OfflineLifecycleCoordinator(
+                    _lifecycleEvents,
+                    OnLifecycleSaveRequested,
+                    OnLifecycleReloadRequested,
+                    ShouldReloadOnFocusGain());
+            }
+        }
+
+        private void RebuildTimeSeams()
+        {
+            _awayTimeCalculator = new OfflineAwayTimeCalculator(_clock ?? new SystemClock());
+        }
+
+        private static bool ShouldReloadOnFocusGain()
+        {
+#if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
+            return true;
+#else
+            return false;
+#endif
+        }
+
+        private void OnLifecycleSaveRequested(string phase)
+        {
+            Debug.LogWarning(
+                $"[OfflineTimeDiag] AppLifecycle | phase={phase}, platform={Application.platform}, " +
+                $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
+                $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
+            SaveForQuit();
+        }
+
+        private void OnLifecycleReloadRequested()
+        {
+            Load();
+        }
+
+        internal void ConfigureRuntimeSeamsForTests(
+            IClock clock = null,
+            ISaveStore saveStore = null,
+            ManualLifecycleEvents lifecycleEvents = null)
+        {
+            if (clock != null) _clock = clock;
+            if (saveStore != null) _saveStore = saveStore;
+            if (lifecycleEvents != null) _lifecycleEvents = lifecycleEvents;
+
+            RebuildTimeSeams();
+
+            _offlineLifecycleCoordinator?.Dispose();
+            _offlineLifecycleCoordinator = null;
+            EnsureRuntimeSeamsInitialized();
+        }
+
+        private string FormatUtcForOfflineDiag(DateTime value)
+        {
+            if (value == default) return "0001-01-01T00:00:00.0000000Z";
+            return value.ToString("o", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs.meta
+++ b/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7fe695067ff499581fbefb4dc203cf0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -30,22 +30,30 @@ using UnityEditor;
 
 /*
  * Oracle (Core Partial)
- * Purpose: Main game-state root that coordinates save state, debug tooling, and parity/diagnostic helpers.
+ * Purpose: Main game-state root that coordinates save state, Infinity/Quantum resets, debug tooling, and parity helpers.
  * Runs: Runtime (MonoBehaviour in Game scene), with editor-only utilities enabled via context menus.
- * Primary entry points in this file: DebugRunFacilityParityTests(), DebugCompareDataCenterProduction(), debug logging
- * helpers for data-driven breakdowns.
+ * Primary entry points in this file: Start(), Update(), Awake(), lifecycle callbacks (OnApplicationQuit/Pause/Focus),
+ * DysonInfinity(), ManualDysonInfinity(), EnactPrestigePlus(), PrestigeDoubleWiper(), plus debug parity/log helpers.
  * Owns vs delegates: Owns orchestration and persisted state containers; delegates production/stat formulas to
- * ProductionSystem, FacilityRuntimeBuilder, and legacy bridge/stat calculators.
+ * ProductionSystem, FacilityRuntimeBuilder, and legacy bridge/stat calculators. Delegates lifecycle routing and
+ * seam-backed time/save abstractions to Oracle.RuntimeSeams + Systems.Save helpers.
  *
  * Interacts with:
+ * - Called by Assets/Scripts/Systems/GameManager.cs (Prestige flow), plus Unity context menus/inspector wiring.
  * - Assets/Scripts/Systems/ProductionSystem.cs (authoritative runtime production behavior)
  * - Assets/Scripts/Systems/Facilities/FacilityLegacyBridge.cs (legacy characterization runtime for parity checks)
  * - Assets/Scripts/Systems/Stats/*.cs pipelines (data-driven stat computation and contribution breakdowns)
+ * - Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs (IClock/ISaveStore/ILifecycleEvents wiring + lifecycle policy)
  *
  * Change notes:
+ * - SaveDataSettings field names are persistence/export keys; renaming `offlineTimeUsedThisInfinity` or
+ *   `offlineTimeUsedPreviousInfinity` requires compatibility/migration coordination.
+ * - Infinity reset boundary ordering must keep offline usage rollover before Infinity data is reinitialized.
  * - Parity formulas in debug helpers must track runtime formula ordering exactly, or false-positive parity deltas appear.
  * - Debug contribution ids/order are used for diagnosis; keep labels stable when adjusting formulas.
  * - Changes here do not migrate saves directly but can change interpretation of existing save-state numbers.
+ * - Lifecycle callbacks are routed through RuntimeSeams; callback policy changes must stay aligned with
+ *   OfflineLifecycleCoordinator tests.
  */
 
 namespace Expansion
@@ -65,8 +73,10 @@ namespace Expansion
     /// <para>Clipboard UI entrypoints: <c>Assets/Scripts/Expansion/Oracle.Clipboard.cs</c>.</para>
     /// <para>Migrations + ensure steps: <c>Assets/Scripts/Expansion/Oracle.Migrations.cs</c>.</para>
     /// <para>Change notes: <see cref="SaveDataSettings"/> includes tab preset override preferences (Bots/Research) that
-    /// export/import with the save. Skill point reconciliation is a manual fix tool (see
-    /// <c>Assets/Scripts/Expansion/Oracle.SkillPoints.cs</c>).</para>
+    /// export/import with the save. Infinity reset boundaries in this class also roll
+    /// <see cref="SaveDataSettings.offlineTimeUsedThisInfinity"/> into
+    /// <see cref="SaveDataSettings.offlineTimeUsedPreviousInfinity"/>. Skill point reconciliation is a manual fix
+    /// tool (see <c>Assets/Scripts/Expansion/Oracle.SkillPoints.cs</c>).</para>
     /// </remarks>
     public partial class Oracle : SerializedMonoBehaviour
     {
@@ -328,47 +338,25 @@ private void PackSettingsFlags()
 
         private void OnApplicationQuit()
         {
-            Debug.LogWarning(
-                $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationQuit, platform={Application.platform}, " +
-                $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
-                $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
-            SaveForQuit();
+            EnsureRuntimeSeamsInitialized();
+            _lifecycleEvents?.RaiseQuitRequested();
         }
 
         #if !UNITY_EDITOR
         #if UNITY_IOS || UNITY_ANDROID
         void OnApplicationPause(bool pauseStatus)
         {
-            if (!pauseStatus) return;
-
-            Debug.LogWarning(
-                $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationPause, platform={Application.platform}, " +
-                $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
-                $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
-            SaveForQuit();
+            EnsureRuntimeSeamsInitialized();
+            _lifecycleEvents?.RaisePauseChanged(pauseStatus);
         }
         #endif
 
         void OnApplicationFocus(bool focus)
         {
-            if (focus)
-            {
-#if UNITY_IOS
-            Load();
-#elif UNITY_ANDROID
-            Load();
+            EnsureRuntimeSeamsInitialized();
+            _lifecycleEvents?.RaiseFocusChanged(focus);
+        }
 #endif
-            }
-                if (!focus)
-                {
-                    Debug.LogWarning(
-                        $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationFocusLost, platform={Application.platform}, " +
-                        $"ready={_isSaveReady.ToString().ToLowerInvariant()}, loaded={Loaded.ToString().ToLowerInvariant()}, " +
-                        $"dateQuitBefore='{FormatDebugString(saveSettings?.dateQuitString)}'");
-                    SaveForQuit();
-                }
-            }
-            #endif
 
 
         #region NewsTicker
@@ -3584,6 +3572,7 @@ private void PackSettingsFlags()
 
             // Load entitlements early so debug gating doesn't depend on PlayerPrefs.
             PlayerEntitlementsStore.EnsureLoaded();
+            EnsureRuntimeSeamsInitialized();
         }
 
         #endregion

--- a/Assets/Scripts/Systems/ProductionSystem.cs
+++ b/Assets/Scripts/Systems/ProductionSystem.cs
@@ -22,6 +22,8 @@ using static Expansion.Oracle;
  * Change notes:
  * - The meaning of infinityData.*Production fields is consumed by UI and offline simulation; keep naming/assignment
  *   semantics stable when adjusting formulas.
+ * - Facility card production fields for data centers/planets should represent the same total per-second amount that is
+ *   actually applied to resources each tick (avoid base-only display fields that diverge from runtime totals).
  * - Data center -> server production must remain strictly deltaTime-scaled in this system to avoid frame-rate
  *   dependent gains.
  * - Any formula changes here should be mirrored in Oracle parity/debug helpers and legacy bridge characterization.
@@ -115,11 +117,11 @@ namespace Systems
             if (skillTreeData.avocados && infinityData.planets[1] >= 69) baseProduction *= 2;
             if (skillTreeData.superchargedPower) baseProduction *= 1.5f;
 
-            infinityData.planetsDataCenterProduction = baseProduction;
-
             bool hasRuntime = FacilityRuntimeBuilder.TryBuildRuntime("planets", infinityData, prestigeData, skillTreeData, null,
                 out FacilityRuntime runtime);
             infinityData.dataCenterProduction = hasRuntime ? runtime.State.ProductionRate : 0;
+            // UI-facing "Planets -> Data Centers" should mirror applied gain, not base-only production.
+            infinityData.planetsDataCenterProduction = infinityData.dataCenterProduction;
 
             double dataCenterProductionTemp = skillTreeData.pocketDimensions && infinityData.workers > 1
                 ? Math.Log10(infinityData.workers)
@@ -177,21 +179,19 @@ namespace Systems
         public static void CalculateDataCenterProduction(DysonVerseInfinityData infinityData, DysonVerseSkillTreeData skillTreeData,
             DysonVersePrestigeData prestigeData, PrestigePlus prestigePlus, double deltaTime)
         {
-            double baseProduction;
             double finalProduction;
             if (FacilityRuntimeBuilder.TryBuildRuntime("data_centers", infinityData, prestigeData, skillTreeData, prestigePlus,
                     out FacilityRuntime runtime))
             {
                 finalProduction = runtime.State.ProductionRate;
-                baseProduction = finalProduction - infinityData.rudimentrySingularityProduction;
             }
             else
             {
-                baseProduction = 0;
                 finalProduction = 0;
             }
 
-            infinityData.dataCenterServerProduction = baseProduction;
+            // UI-facing "Data Centers -> Servers" should mirror applied gain, not base-only production.
+            infinityData.dataCenterServerProduction = finalProduction;
             infinityData.serverProduction = finalProduction;
             infinityData.servers[0] += infinityData.serverProduction * deltaTime;
         }

--- a/Assets/Scripts/Systems/Save/IClock.cs
+++ b/Assets/Scripts/Systems/Save/IClock.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Systems.Save
+{
+    /*
+     * IClock / SystemClock
+     * Purpose (runtime): Stable seam for UTC time retrieval used by save/lifecycle/offline-time logic.
+     * Runs: Runtime and editor tests.
+     * Primary entry points:
+     * - IClock.UtcNow
+     * - SystemClock.UtcNow
+     * Owns vs delegates:
+     * - Owns only the "what time is it" contract.
+     * - Delegates actual wall-clock retrieval to DateTime.UtcNow (SystemClock implementation).
+     *
+     * Interacts with:
+     * - Systems.Save.OfflineAwayTimeCalculator
+     * - Expansion.Oracle (save-for-quit timestamping and load-time diagnostics)
+     * - Editor tests under Assets/Editor/Tests/** via fake clocks
+     *
+     * Change notes:
+     * - If UtcNow semantics change, offline-time grant and quit timestamp logic can drift or regress.
+     * - Keep UTC-only behavior; switching to local time requires coordinated updates to parsing/clamping tests.
+     */
+    public interface IClock
+    {
+        DateTime UtcNow { get; }
+    }
+
+    public sealed class SystemClock : IClock
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/Assets/Scripts/Systems/Save/IClock.cs.meta
+++ b/Assets/Scripts/Systems/Save/IClock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e75e3b9831a9493ea3324b88991f11b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Save/ILifecycleEvents.cs
+++ b/Assets/Scripts/Systems/Save/ILifecycleEvents.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Systems.Save
+{
+    /*
+     * ILifecycleEvents / ManualLifecycleEvents
+     * Purpose (runtime): Testable signal surface for app lifecycle transitions (pause/focus/quit).
+     * Runs: Runtime and editor tests.
+     * Primary entry points:
+     * - ILifecycleEvents.PauseChanged
+     * - ILifecycleEvents.FocusChanged
+     * - ILifecycleEvents.QuitRequested
+     * - ManualLifecycleEvents.Raise* methods (used by Oracle callbacks/tests)
+     * Owns vs delegates:
+     * - Owns event dispatch contract only.
+     * - Delegates lifecycle policy decisions to consumers such as OfflineLifecycleCoordinator.
+     *
+     * Interacts with:
+     * - Systems.Save.OfflineLifecycleCoordinator
+     * - Expansion.Oracle (OnApplicationPause/Focus/Quit bridges)
+     * - Editor tests in Assets/Editor/Tests/Systems/**
+     *
+     * Change notes:
+     * - Renaming/removing events requires synchronized updates across Oracle and lifecycle tests.
+     * - Event ordering assumptions are validated by tests; preserve deterministic dispatch semantics.
+     */
+    public interface ILifecycleEvents
+    {
+        event Action<bool> PauseChanged;
+        event Action<bool> FocusChanged;
+        event Action QuitRequested;
+    }
+
+    public sealed class ManualLifecycleEvents : ILifecycleEvents
+    {
+        public event Action<bool> PauseChanged;
+        public event Action<bool> FocusChanged;
+        public event Action QuitRequested;
+
+        public void RaisePauseChanged(bool paused)
+        {
+            PauseChanged?.Invoke(paused);
+        }
+
+        public void RaiseFocusChanged(bool focused)
+        {
+            FocusChanged?.Invoke(focused);
+        }
+
+        public void RaiseQuitRequested()
+        {
+            QuitRequested?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Save/ILifecycleEvents.cs.meta
+++ b/Assets/Scripts/Systems/Save/ILifecycleEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d8cce68feb2435b82859abad67e927e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Save/ISaveStore.cs
+++ b/Assets/Scripts/Systems/Save/ISaveStore.cs
@@ -1,0 +1,67 @@
+using System;
+using Expansion;
+
+namespace Systems.Save
+{
+    /*
+     * ISaveStore / CanonicalSaveStore
+     * Purpose (runtime): Narrow save-store seam used by Oracle to load/save canonical save snapshots.
+     * Runs: Runtime and editor tests.
+     * Primary entry points:
+     * - ISaveStore.Exists()
+     * - ISaveStore.TryLoad(...)
+     * - ISaveStore.TrySave(...)
+     * - CanonicalSaveStore.CreateDefault()
+     * Owns vs delegates:
+     * - Owns the store-level contract expected by Oracle save lifecycle code.
+     * - Delegates actual encoding/storage to Systems.Save.SaveSystem and Systems.Save.ISaveStorage.
+     *
+     * Interacts with:
+     * - Expansion.Oracle.Persistence (Load/TrySaveState)
+     * - Systems.Save.SaveSystem
+     * - Editor tests in Assets/Editor/Tests/Save/**
+     *
+     * Change notes:
+     * - Changing contract behavior (e.g. TrySave returning false on partial success) affects startup load fallback
+     *   and quit-save persistence flow.
+     * - Keep this abstraction aligned with SaveSystem expectations to avoid split-brain persistence behavior.
+     */
+    public interface ISaveStore
+    {
+        bool Exists();
+
+        bool TryLoad(out Oracle.SaveDataSettings settings, out string error);
+
+        bool TrySave(Oracle.SaveDataSettings settings, out SaveStringStats stats, out string error);
+    }
+
+    public sealed class CanonicalSaveStore : ISaveStore
+    {
+        private readonly SaveSystem _saveSystem;
+
+        public CanonicalSaveStore(SaveSystem saveSystem)
+        {
+            _saveSystem = saveSystem ?? throw new ArgumentNullException(nameof(saveSystem));
+        }
+
+        public static CanonicalSaveStore CreateDefault()
+        {
+            return new CanonicalSaveStore(SaveSystem.CreateDefault());
+        }
+
+        public bool Exists()
+        {
+            return _saveSystem.Storage.Exists();
+        }
+
+        public bool TryLoad(out Oracle.SaveDataSettings settings, out string error)
+        {
+            return _saveSystem.TryLoad(out settings, out error);
+        }
+
+        public bool TrySave(Oracle.SaveDataSettings settings, out SaveStringStats stats, out string error)
+        {
+            return _saveSystem.TrySave(settings, out stats, out error);
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Save/ISaveStore.cs.meta
+++ b/Assets/Scripts/Systems/Save/ISaveStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d18b03cebf84732af5f9106c65a0310
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Save/OfflineAwayTimeCalculator.cs
+++ b/Assets/Scripts/Systems/Save/OfflineAwayTimeCalculator.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Globalization;
+using Expansion;
+
+namespace Systems.Save
+{
+    /*
+     * OfflineAwayTimeCalculator
+     * Purpose (runtime): Canonical away-time resolution from save timestamps with UTC parsing and clamping.
+     * Runs: Runtime and editor tests.
+     * Primary entry points:
+     * - Compute(Oracle.SaveDataSettings)
+     * - TryParseUtc(string, out DateTime)
+     * Owns vs delegates:
+     * - Owns date-source selection (quit string -> dateStarted fallback -> runtime fallback) and away-time math.
+     * - Delegates current-time retrieval to IClock.
+     *
+     * Interacts with:
+     * - Expansion.Oracle.Persistence (AwayForSeconds flow)
+     * - Systems.Save.IClock
+     * - Editor tests in Assets/Editor/Tests/Systems/**
+     *
+     * Change notes:
+     * - Source selection and clamping behavior define offline grant correctness; changes require updating regression tests.
+     * - Parsing must remain UTC-normalized for cross-timezone/device consistency.
+     */
+    public sealed class OfflineAwayTimeCalculator
+    {
+        public enum AwayTimeSource
+        {
+            MissingQuitString,
+            QuitString,
+            DateStartedFallback,
+            RuntimeUtcFallback
+        }
+
+        public readonly struct AwayTimeComputation
+        {
+            public AwayTimeComputation(
+                AwayTimeSource source,
+                DateTime resolvedStartUtc,
+                DateTime nowUtc,
+                float rawSeconds,
+                float clampedSeconds)
+            {
+                Source = source;
+                ResolvedStartUtc = resolvedStartUtc;
+                NowUtc = nowUtc;
+                RawSeconds = rawSeconds;
+                ClampedSeconds = clampedSeconds;
+            }
+
+            public AwayTimeSource Source { get; }
+            public DateTime ResolvedStartUtc { get; }
+            public DateTime NowUtc { get; }
+            public float RawSeconds { get; }
+            public float ClampedSeconds { get; }
+
+            public bool HasQuitTimestampInput => Source != AwayTimeSource.MissingQuitString;
+
+            public string SourceLabel
+            {
+                get
+                {
+                    switch (Source)
+                    {
+                        case AwayTimeSource.QuitString:
+                            return "quitString";
+                        case AwayTimeSource.DateStartedFallback:
+                            return "dateStartedFallback";
+                        case AwayTimeSource.RuntimeUtcFallback:
+                            return "runtimeUtcFallback";
+                        default:
+                            return "missingQuitString";
+                    }
+                }
+            }
+        }
+
+        private readonly IClock _clock;
+
+        public OfflineAwayTimeCalculator(IClock clock)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
+
+        public AwayTimeComputation Compute(Oracle.SaveDataSettings settings)
+        {
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+
+            DateTime nowUtc = _clock.UtcNow;
+            if (string.IsNullOrEmpty(settings.dateQuitString))
+            {
+                return new AwayTimeComputation(
+                    AwayTimeSource.MissingQuitString,
+                    nowUtc,
+                    nowUtc,
+                    0f,
+                    0f);
+            }
+
+            AwayTimeSource source = AwayTimeSource.QuitString;
+            if (!TryParseUtc(settings.dateQuitString, out DateTime resolvedStartUtc))
+            {
+                source = AwayTimeSource.DateStartedFallback;
+                if (!TryParseUtc(settings.dateStarted, out resolvedStartUtc))
+                {
+                    source = AwayTimeSource.RuntimeUtcFallback;
+                    resolvedStartUtc = nowUtc;
+                }
+            }
+
+            float rawSeconds = (float)(nowUtc - resolvedStartUtc).TotalSeconds;
+            float clampedSeconds = Math.Max(0f, rawSeconds);
+            return new AwayTimeComputation(source, resolvedStartUtc, nowUtc, rawSeconds, clampedSeconds);
+        }
+
+        public static bool TryParseUtc(string value, out DateTime result)
+        {
+            return DateTime.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out result);
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Save/OfflineAwayTimeCalculator.cs.meta
+++ b/Assets/Scripts/Systems/Save/OfflineAwayTimeCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a833c925b9894140b437f7a9544e9697
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs
+++ b/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace Systems.Save
+{
+    /*
+     * OfflineLifecycleCoordinator
+     * Purpose (runtime): Centralizes lifecycle-trigger policy for save-on-background/quit and optional focus reload.
+     * Runs: Runtime and editor tests.
+     * Primary entry points:
+     * - constructor (subscribes to ILifecycleEvents)
+     * - Dispose() (unsubscribes)
+     * Owns vs delegates:
+     * - Owns the lifecycle policy matrix:
+     *   pause(true) => request save, focus(false) => request save, quit => request save, focus(true) => optional reload.
+     * - Delegates actual save/load work to injected callbacks.
+     *
+     * Interacts with:
+     * - Systems.Save.ILifecycleEvents
+     * - Expansion.Oracle (save/reload callbacks)
+     * - Editor tests validating lifecycle permutations
+     *
+     * Change notes:
+     * - Callback ordering materially affects persistence reliability; keep pause/focus/quit routing consistent.
+     * - If focus-gain reload policy changes, update mobile behavior tests and Oracle integration docs together.
+     */
+    public sealed class OfflineLifecycleCoordinator : IDisposable
+    {
+        private readonly ILifecycleEvents _events;
+        private readonly Action<string> _requestSaveForQuit;
+        private readonly Action _requestReloadOnFocusGain;
+        private readonly bool _reloadOnFocusGain;
+        private bool _disposed;
+
+        public OfflineLifecycleCoordinator(
+            ILifecycleEvents lifecycleEvents,
+            Action<string> requestSaveForQuit,
+            Action requestReloadOnFocusGain,
+            bool reloadOnFocusGain)
+        {
+            _events = lifecycleEvents ?? throw new ArgumentNullException(nameof(lifecycleEvents));
+            _requestSaveForQuit = requestSaveForQuit ?? throw new ArgumentNullException(nameof(requestSaveForQuit));
+            _requestReloadOnFocusGain = requestReloadOnFocusGain ?? throw new ArgumentNullException(nameof(requestReloadOnFocusGain));
+            _reloadOnFocusGain = reloadOnFocusGain;
+
+            _events.PauseChanged += HandlePauseChanged;
+            _events.FocusChanged += HandleFocusChanged;
+            _events.QuitRequested += HandleQuitRequested;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            _events.PauseChanged -= HandlePauseChanged;
+            _events.FocusChanged -= HandleFocusChanged;
+            _events.QuitRequested -= HandleQuitRequested;
+        }
+
+        private void HandlePauseChanged(bool paused)
+        {
+            if (!paused) return;
+            _requestSaveForQuit("OnApplicationPause");
+        }
+
+        private void HandleFocusChanged(bool focused)
+        {
+            if (focused)
+            {
+                if (_reloadOnFocusGain)
+                {
+                    _requestReloadOnFocusGain();
+                }
+
+                return;
+            }
+
+            _requestSaveForQuit("OnApplicationFocusLost");
+        }
+
+        private void HandleQuitRequested()
+        {
+            _requestSaveForQuit("OnApplicationQuit");
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs.meta
+++ b/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca9d6051c9104c9c8361e25cf93c54de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/Code/OfflineProgressExecutionMap.md
+++ b/Documentation/Code/OfflineProgressExecutionMap.md
@@ -1,0 +1,154 @@
+# Offline Progress Execution Map
+
+## Scope
+- Runtime paths that influence:
+  - save persistence correctness,
+  - quit timestamp stamping,
+  - away-time resolution,
+  - offline-time grant/apply flow.
+- Verified against current code in:
+  - `Assets/Scripts/Expansion/Oracle.cs`
+  - `Assets/Scripts/Expansion/Oracle.Persistence.cs`
+  - `Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs`
+  - `Assets/Scripts/Expansion/Oracle.SaveScheduling.cs`
+  - `Assets/Scripts/Systems/OfflineProgressSystem.cs`
+  - `Assets/Scripts/Systems/GameManager.cs`
+  - `Assets/Scripts/Systems/Save/*.cs` seam/store files
+
+## Trigger -> Service -> Persistence -> Side Effect
+
+### Startup load path
+1. Trigger: `Oracle.Start()` (`Assets/Scripts/Expansion/Oracle.cs`)
+2. Service chain:
+   - `Load()`
+   - canonical load via `_saveStore.TryLoad(...)` (`CanonicalSaveStore -> SaveSystem`)
+   - legacy fallback selection (`SaveLoadCandidateSelector`, ES3 probes, legacy Odin file probes)
+3. Persistence:
+   - canonical: `ISaveStore` (`Assets/Scripts/Systems/Save/ISaveStore.cs`)
+   - underlying storage: `SaveSystem` + `ISaveStorage` (`OdinStringFileStorage`)
+4. Side effects:
+   - `ApplyLoadedSettings(...)`
+   - `ApplyMigrations()`
+   - `AwayForCoroutine()` then `AwayForSeconds()`
+   - autosave readiness via `SetSaveReady(true)`
+   - canonical rewrite after legacy load
+
+### Quit/background save path
+1. Trigger:
+   - `OnApplicationQuit()`
+   - `OnApplicationPause(true)` (mobile, non-editor)
+   - `OnApplicationFocus(false)` (non-editor)
+2. Service chain:
+   - callbacks raise `ManualLifecycleEvents`
+   - `OfflineLifecycleCoordinator` maps event -> `OnLifecycleSaveRequested(phase)`
+   - `SaveForQuit()`
+   - `SaveInternal(force:false, updateQuitTime:true)`
+   - `TrySaveState()`
+3. Persistence:
+   - `SetDateQuitString(_clock.UtcNow.ToString(...), isQuitTimestamp:true)`
+   - snapshot compaction via `SaveSnapshotBuilder`
+   - `_saveStore.TrySave(snapshot, ...)`
+4. Side effects:
+   - offline diagnostic logs (`[OfflineTimeDiag]`)
+   - latest save state and quit timestamp persisted atomically
+
+### Focus gain reload path (mobile builds)
+1. Trigger: `OnApplicationFocus(true)` (mobile player builds)
+2. Service chain:
+   - callback raises `ManualLifecycleEvents`
+   - `OfflineLifecycleCoordinator` invokes `OnLifecycleReloadRequested()`
+   - `Load()`
+3. Persistence:
+   - `_saveStore.TryLoad(...)` canonical-first fallback flow
+4. Side effects:
+   - resolves away-time from persisted quit timestamp
+   - invokes `AwayFor` event for offline grant path
+
+### Away-time resolution + offline grant path
+1. Trigger: `AwayForCoroutine()` -> `AwayForSeconds()` (`Oracle.Persistence`)
+2. Service chain:
+   - `OfflineAwayTimeCalculator.Compute(saveSettings)` using `IClock.UtcNow`
+   - source priority: `dateQuitString` -> `dateStarted` -> runtime UTC fallback
+   - clamps negative away-time to `0`
+   - raises `AwayFor?.Invoke(clampedSeconds)`
+3. Persistence touchpoints:
+   - increments `saveSettings.sdPrestige.doubleTime`
+4. Side effects:
+   - `GameManager.ApplyReturnValues(double awayTime)` subscriber
+   - `OfflineProgressSystem.ApplyReturnValues(...)`
+   - mutates `saveSettings.offlineTime` capped by `saveSettings.maxOfflineTime`
+
+### Offline time spend/apply path (user spends stored time)
+1. Trigger: `OfflineTimeManager` button/slider actions
+2. Service chain:
+   - `GameManager.RunAwayTime(...)`
+   - coroutine `OfflineProgressSystem.CalculateAwayValues(...)`
+3. Persistence touchpoints:
+   - consumes `saveSettings.offlineTime`
+   - mutates runtime resources in `DysonVerseInfinityData`
+4. Side effects:
+   - return-screen UI text/progress updates
+
+### Autosave path
+1. Trigger: `Oracle.SaveScheduling.ScheduleAutoSave()` (`InvokeRepeating(nameof(Save), 60, 60)`)
+2. Service chain:
+   - `Save()` -> `SaveInternal(force:false, updateQuitTime:false)` -> `TrySaveState()`
+3. Persistence:
+   - canonical snapshot save through `_saveStore`
+4. Side effects:
+   - no quit timestamp overwrite on autosave
+
+## Lifecycle permutation coverage in editor tests
+- `Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs`
+  - `focus lost -> pause -> quit`
+  - `pause true -> pause false -> quit`
+  - rapid focus toggles
+  - focus-gain reload enabled policy
+  - unsubscribe/dispose behavior
+
+## Offline/save regression coverage in editor tests
+- `Assets/Editor/Tests/Systems/OfflineAwayTimeCalculatorTests.cs`
+  - UTC parse + fallback + clamp behavior.
+- `Assets/Editor/Tests/Systems/OfflineProgressSystemTests.cs`
+  - positive/zero/negative/cap offline grant behavior.
+- `Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs`
+  - matrix-driven reopen windows: 2m / 15m / 60m.
+  - verifies latest progress persists and offline time is granted across repeated close/open cycles.
+- `Assets/Editor/Tests/Save/CanonicalSaveStoreTests.cs`
+  - canonical save-store roundtrip and latest-write-wins persistence.
+
+## Headless test commands
+
+### EditMode (primary)
+```bash
+/Applications/Unity/Hub/Editor/6000.3.7f1/Unity.app/Contents/MacOS/Unity \
+  -batchmode -nographics -quit \
+  -projectPath "/Users/matthewrushworth/Projects/Idle Dyson Swarm" \
+  -runTests -testPlatform EditMode \
+  -testResults "/Users/matthewrushworth/Projects/Idle Dyson Swarm/Documentation/TestResults/editmode-results.xml" \
+  -logFile "/Users/matthewrushworth/Projects/Idle Dyson Swarm/Documentation/TestResults/editmode.log"
+```
+
+### PlayMode (smoke/integration when needed)
+```bash
+/Applications/Unity/Hub/Editor/6000.3.7f1/Unity.app/Contents/MacOS/Unity \
+  -batchmode -nographics -quit \
+  -projectPath "/Users/matthewrushworth/Projects/Idle Dyson Swarm" \
+  -runTests -testPlatform PlayMode \
+  -testResults "/Users/matthewrushworth/Projects/Idle Dyson Swarm/Documentation/TestResults/playmode-results.xml" \
+  -logFile "/Users/matthewrushworth/Projects/Idle Dyson Swarm/Documentation/TestResults/playmode.log"
+```
+
+## Ranked fix proposal template from failing tests
+1. Lifecycle save ordering/timing
+   - Confirm: lifecycle test failures show missing save callback on expected transitions.
+   - Falsify: callback counts are correct; failure is downstream persistence.
+2. Timestamp normalization (UTC source/parsing)
+   - Confirm: away-time calculator tests fail around offset/fallback/clamp expectations.
+   - Falsify: away-time math is correct; failure is save timestamp not being written.
+3. Stale write / latest-write loss
+   - Confirm: save-store or regression test loads older snapshot after a newer save.
+   - Falsify: latest-write always wins; issue is in grant/application path.
+4. Profile/slot/load-source mismatch
+   - Confirm: load candidate selection chooses unexpected source/version in diagnostics.
+   - Falsify: canonical/expected candidate selected consistently.

--- a/Documentation/Code/Oracle.Persistence.md
+++ b/Documentation/Code/Oracle.Persistence.md
@@ -2,13 +2,14 @@
 
 ## Contract / behavior expectations
 - `Load()` must prefer canonical save storage first (`idle_dyson_swarm_save.txt`) and only fall back to legacy sources when canonical load is missing or invalid.
+- Canonical load/save now routes through `ISaveStore` (default `CanonicalSaveStore`) rather than directly constructing `SaveSystem` at each call site.
 - Legacy fallback selection is version/timestamp/source-priority based through `SaveLoadCandidateSelector`.
 - If no candidate can be loaded and ES3 access was broken, legacy ES3 artifacts are archived as `.corrupt.*` for support triage.
 - If load succeeds from any legacy source, canonical save is immediately rewritten so subsequent launches avoid legacy paths.
 
 ## Data flow
 1. `Load()` resets in-memory state with `WipeSaveData()`.
-2. Attempts canonical load via `SaveSystem`.
+2. Attempts canonical load via `_saveStore` (`CanonicalSaveStore -> SaveSystem`).
 3. If needed, probes:
    - `ES3` default key (`saveSettings`),
    - `LegacyEs3Save.TryRecoverDefaultSave` (main + backup + archived artifacts),
@@ -18,18 +19,20 @@
 
 ## Offline timing diagnostics
 - Runtime emits `[OfflineTimeDiag]` warnings from:
-  - `Oracle.OnApplicationQuit`, `Oracle.OnApplicationFocus`, and `Oracle.OnApplicationPause` (platform/ready/loaded/dateQuit pre-save) via `SaveForQuit`
+  - `Oracle.RuntimeSeams` lifecycle router (`OnApplicationQuit`, `OnApplicationFocus`, `OnApplicationPause`) via `OfflineLifecycleCoordinator` -> `SaveForQuit`
   - `Oracle.SaveInternal` (save lifecycle snapshots when quit timestamp is updated or save fails)
-  - `Oracle.AwayForSeconds` (chosen source, parsed timestamps, and resolved away span)
+  - `Oracle.AwayForSeconds` via `OfflineAwayTimeCalculator` (chosen source, parsed timestamps, and resolved away span)
   - `Systems.OfflineProgressSystem.ApplyReturnValues` (pre/post `offlineTime` grant)
 
 ## Save lifecycle semantics
 - `Oracle.Save()` is a regular autosave path and **does not** update `dateQuitString`.
 - `Oracle.SaveForQuit()` writes the quit timestamp only when the runtime is ready + loaded (`_isSaveReady && Loaded && saveSettings != null`).
+- Quit timestamp writes now use `IClock.UtcNow` seam to support deterministic tests.
 - `Oracle.SaveForQuit()` is called from:
-  - `Oracle.OnApplicationQuit`
-  - `Oracle.OnApplicationFocus` when focus is lost (non-editor builds)
-  - `Oracle.OnApplicationPause` while paused (iOS/Android)
+  - `OfflineLifecycleCoordinator` callbacks from `Oracle` lifecycle events:
+    - `OnApplicationQuit`
+    - `OnApplicationFocus` when focus is lost (non-editor builds)
+    - `OnApplicationPause` while paused (iOS/Android)
 - `Oracle.SaveInternal` now uses `SetDateQuitString(string value, bool isQuitTimestamp = false)` to update `dateQuitString` only when `isQuitTimestamp` is explicitly true.
 - `Oracle.SaveForQuit()` now emits `[OfflineTimeDiag] SaveForQuitBlocked` when lifecycle persistence is attempted before readiness/loading and skips writing.
 
@@ -44,7 +47,11 @@
 - Keep heavy deserialization off hot loops; startup load path runs on app launch and scene entry.
 
 ## Quick verification steps
-1. Launch with valid canonical save: confirm `Loaded with canonical save file`.
-2. Remove canonical file but keep valid ES3 file: confirm ES3 fallback loads and canonical file is rewritten.
-3. Provide AES-encrypted `SaveFile.es3` legacy artifact: confirm recovery succeeds (no `unrecoverable` archive on first run with fix).
-4. With only invalid artifacts: confirm archive still occurs and a new save is created.
+1. Run EditMode headless tests:
+   - `OfflineAwayTimeCalculatorTests`
+   - `OfflineLifecycleCoordinatorTests`
+   - `OfflinePersistenceRegressionTests`
+2. Launch with valid canonical save: confirm `Loaded with canonical save file`.
+3. Remove canonical file but keep valid ES3 file: confirm ES3 fallback loads and canonical file is rewritten.
+4. Provide AES-encrypted `SaveFile.es3` legacy artifact: confirm recovery succeeds (no `unrecoverable` archive on first run with fix).
+5. With only invalid artifacts: confirm archive still occurs and a new save is created.

--- a/Documentation/Code/Oracle.RuntimeSeams.md
+++ b/Documentation/Code/Oracle.RuntimeSeams.md
@@ -1,0 +1,32 @@
+# Oracle.RuntimeSeams
+
+## Contract / behavior expectations
+- `EnsureRuntimeSeamsInitialized()` must provide non-null defaults for:
+  - `IClock` (`SystemClock`)
+  - `ISaveStore` (`CanonicalSaveStore.CreateDefault()`)
+  - `OfflineAwayTimeCalculator`
+  - `ManualLifecycleEvents` + `OfflineLifecycleCoordinator`
+- Oracle lifecycle callbacks must only raise lifecycle events; policy routing lives in `OfflineLifecycleCoordinator`.
+- Save requests from lifecycle routing must still flow through `SaveForQuit()` so readiness guards remain authoritative.
+
+## Data flow
+1. `Oracle.Awake()` calls `EnsureRuntimeSeamsInitialized()`.
+2. Unity lifecycle callback fires (`OnApplicationQuit`, `OnApplicationPause`, `OnApplicationFocus`).
+3. Callback raises `ManualLifecycleEvents`.
+4. `OfflineLifecycleCoordinator` maps event to:
+   - `OnLifecycleSaveRequested(phase)` -> `SaveForQuit()`
+   - `OnLifecycleReloadRequested()` -> `Load()` (mobile focus gain policy only)
+5. `Oracle.Persistence` uses initialized seams for timestamping (`IClock`) and canonical persistence (`ISaveStore`).
+
+## Save/load implications
+- `IClock` controls all seam-backed quit/load timestamps used by offline-time diagnostics.
+- Replacing `ISaveStore` in tests changes where canonical snapshots are read/written but keeps Oracle behavior unchanged.
+
+## Performance pitfalls
+- `Load()` on focus gain is intentionally gated by platform (`!UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)`) to avoid expensive reload loops on desktop/editor.
+- Do not allocate/rebuild coordinators repeatedly during normal gameplay; wiring is expected once per Oracle lifetime.
+
+## Quick verification steps
+1. Run `OfflineLifecycleCoordinatorTests` to validate event routing matrix.
+2. Run `OfflineAwayTimeCalculatorTests` to validate timestamp source/clamp behavior.
+3. Run `OfflinePersistenceRegressionTests` to validate close/open persistence + offline grant matrix.

--- a/Documentation/Code/ProductionSystem.md
+++ b/Documentation/Code/ProductionSystem.md
@@ -6,9 +6,13 @@
 ## Contract / behavior expectations
 - `CalculateProduction(...)` defines facility update ordering for each tick.
 - `CalculateDataCenterProduction(...)` writes:
-  - `infinityData.dataCenterServerProduction` = data-center production before rudimentary singularity add-on.
+  - `infinityData.dataCenterServerProduction` = total runtime data-center production (matches applied server gain per second).
   - `infinityData.serverProduction` = final runtime production from the data-center pipeline.
   - `infinityData.servers[0] += infinityData.serverProduction * deltaTime`.
+- `CalculatePlanetProduction(...)` writes:
+  - `infinityData.planetsDataCenterProduction` = total runtime planet production (matches applied data-center gain per second).
+  - `infinityData.dataCenterProduction` = final runtime production from the planet pipeline.
+  - `infinityData.dataCenters[0] += infinityData.dataCenterProduction * deltaTime`.
 - Parallel Computation is now fully represented inside the data-driven runtime pipeline; there is no separate post-pipeline add/subtract path in `ProductionSystem`.
 
 ## Data flow
@@ -20,7 +24,8 @@
 ## Save/load implications
 - No save-field additions/removals.
 - Existing values are recalculated from current state each tick.
-- Behavior change affects `serverProduction` magnitude (by design) but does not require migration.
+- `dataCenterServerProduction` and `planetsDataCenterProduction` now represent total applied gain rates (not base-only values).
+- No migration required because these are derived runtime fields.
 
 ## Performance pitfalls
 - Keep production methods allocation-free; they run every frame.
@@ -28,8 +33,8 @@
 - Keep updates deltaTime-scaled to avoid frame-rate dependent gains.
 
 ## Quick verification steps
-1. Enable Parallel Computation with `serversTotal > 1`; verify `serverProduction` already includes the multiplier.
-2. Confirm `CalculateDataCenterProduction` has no standalone additive parallel increment.
-3. Confirm offline progression uses `serverProduction * seconds` with no extra parallel term.
-4. Compare realtime and offline gains over the same simulated duration for consistency.
-5. Use Oracle parity logs to confirm expected/data-driven values remain aligned.
+1. Enable Rudimentary Singularity and verify `dataCenterServerProduction == serverProduction` and both match `servers` delta over 1 second.
+2. Enable Pocket Dimensions and verify `planetsDataCenterProduction == dataCenterProduction` and both match `dataCenters` delta over 1 second.
+3. Confirm facility card production text, bot-panel progress bar rates, and facility breakdown popup all show the same total rate.
+4. Confirm offline progression uses `serverProduction * seconds` and `dataCenterProduction * seconds` with no extra duplicate add.
+5. Compare realtime and offline gains over the same simulated duration for consistency.

--- a/Documentation/Test Results/AssetImportWorker1-prev.xml
+++ b/Documentation/Test Results/AssetImportWorker1-prev.xml
@@ -1,0 +1,807 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="2" testcasecount="106" result="Failed(Child)" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.0764617">
+  <test-suite type="TestSuite" id="1138" name="Idle Dyson Swarm" fullname="Idle Dyson Swarm" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.076462" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+    <properties>
+      <property name="platform" value="EditMode" />
+    </properties>
+    <failure>
+      <message><![CDATA[One or more child tests had errors]]></message>
+    </failure>
+    <test-suite type="Assembly" id="1127" name="Assembly-CSharp-Editor.dll" fullname="/Users/matthewrushworth/Projects/Idle Dyson Swarm/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.074211" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_PID" value="10104" />
+        <property name="_APPDOMAIN" value="Unity Child Domain" />
+        <property name="platform" value="EditMode" />
+        <property name="EditorOnly" value="True" />
+      </properties>
+      <failure>
+        <message><![CDATA[One or more child tests had errors]]></message>
+      </failure>
+      <test-suite type="TestSuite" id="1128" name="Tests" fullname="Tests" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.073358" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <failure>
+          <message><![CDATA[One or more child tests had errors]]></message>
+        </failure>
+        <test-suite type="TestSuite" id="1132" name="Investigations" fullname="Tests.Investigations" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.018124" total="4" passed="0" failed="4" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <failure>
+            <message><![CDATA[One or more child tests had errors]]></message>
+          </failure>
+          <test-suite type="TestFixture" id="1122" name="ProductionUiMismatchTests" fullname="Tests.Investigations.ProductionUiMismatchTests" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.017801" total="4" passed="0" failed="4" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <failure>
+              <message><![CDATA[One or more child tests had errors]]></message>
+            </failure>
+            <test-case id="1125" name="DataCenters_Control_NoRudimentary_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_Control_NoRudimentary_ParityHolds" methodname="DataCenters_Control_NoRudimentary_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="407581522" result="Failed" label="Error" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.016558" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculateDataCenterModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x000ac] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:270 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000c8] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:210 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculateDataCenterProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double deltaTime) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:182 
+  at Tests.Investigations.ProductionUiMismatchTests.DataCenters_Control_NoRudimentary_ParityHolds () [0x0003f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:95 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1123" name="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate" methodname="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="350197462" result="Failed" label="Error" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000250" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculateDataCenterModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x000ac] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:270 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000c8] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:210 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculateDataCenterProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double deltaTime) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:182 
+  at Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate () [0x0004e] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:49 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1126" name="Planets_Control_NoPocketDimensions_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_Control_NoPocketDimensions_ParityHolds" methodname="Planets_Control_NoPocketDimensions_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="898510072" result="Failed" label="Error" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000215" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculatePlanetModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.SecretBuffState secrets, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x00217] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:344 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000dc] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:213 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculatePlanetProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, System.Double deltaTime) [0x00065] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:120 
+  at Tests.Investigations.ProductionUiMismatchTests.Planets_Control_NoPocketDimensions_ParityHolds () [0x00047] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:118 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1124" name="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" methodname="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="977217062" result="Failed" label="Error" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000214" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculatePlanetModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.SecretBuffState secrets, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x00217] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:344 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000dc] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:213 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculatePlanetProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, System.Double deltaTime) [0x00065] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:120 
+  at Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate () [0x00047] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:72 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1131" name="Save" fullname="Tests.Save" runstate="Runnable" testcasecount="18" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.030719" total="18" passed="18" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1098" name="CanonicalSaveStoreTests" fullname="Tests.Save.CanonicalSaveStoreTests" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.003466" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1099" name="TrySaveThenTryLoad_RoundTripsCanonicalSettings" fullname="Tests.Save.CanonicalSaveStoreTests.TrySaveThenTryLoad_RoundTripsCanonicalSettings" methodname="TrySaveThenTryLoad_RoundTripsCanonicalSettings" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" seed="111776317" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000924" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1100" name="TrySaveTwice_TryLoadReturnsLatestSnapshot" fullname="Tests.Save.CanonicalSaveStoreTests.TrySaveTwice_TryLoadReturnsLatestSnapshot" methodname="TrySaveTwice_TryLoadReturnsLatestSnapshot" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" seed="1226007045" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001246" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1101" name="FacilityArrayNormalizerTests" fullname="Tests.Save.FacilityArrayNormalizerTests" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002098" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1106" name="ClearSparseLists_SetsAllSparseListsToNull" fullname="Tests.Save.FacilityArrayNormalizerTests.ClearSparseLists_SetsAllSparseListsToNull" methodname="ClearSparseLists_SetsAllSparseListsToNull" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="766070654" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000045" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1104" name="EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" fullname="Tests.Save.FacilityArrayNormalizerTests.EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" methodname="EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="1441672627" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1105" name="EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" fullname="Tests.Save.FacilityArrayNormalizerTests.EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" methodname="EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="56719925" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1103" name="Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" fullname="Tests.Save.FacilityArrayNormalizerTests.Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" methodname="Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="573814582" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1102" name="Normalize_WithNullData_DoesNotThrow" fullname="Tests.Save.FacilityArrayNormalizerTests.Normalize_WithNullData_DoesNotThrow" methodname="Normalize_WithNullData_DoesNotThrow" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="64772652" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000012" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1107" name="OdinStringFileStorageTests" fullname="Tests.Save.OdinStringFileStorageTests" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002743" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1108" name="WriteAndRead_RoundTripsText_AndCreatesBackups" fullname="Tests.Save.OdinStringFileStorageTests.WriteAndRead_RoundTripsText_AndCreatesBackups" methodname="WriteAndRead_RoundTripsText_AndCreatesBackups" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" seed="1465727047" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001418" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1109" name="WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" fullname="Tests.Save.OdinStringFileStorageTests.WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" methodname="WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" seed="2144782004" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000286" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1110" name="SaveCodecCharacterizationTests" fullname="Tests.Save.SaveCodecCharacterizationTests" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.011201" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1111" name="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" fullname="Tests.Save.SaveCodecCharacterizationTests.EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" methodname="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" seed="1855484778" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.010201" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1112" name="EncodeBinary_CompressTrue_UsesGzipHeader" fullname="Tests.Save.SaveCodecCharacterizationTests.EncodeBinary_CompressTrue_UsesGzipHeader" methodname="EncodeBinary_CompressTrue_UsesGzipHeader" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" seed="54885153" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000043" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1113" name="SaveCodecTests" fullname="Tests.Save.SaveCodecTests" classname="Tests.Save.SaveCodecTests" runstate="Runnable" testcasecount="6" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.005812" total="6" passed="6" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1115" name="EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" fullname="Tests.Save.SaveCodecTests.EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" methodname="EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1765478109" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000033" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1114" name="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" fullname="Tests.Save.SaveCodecTests.EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" methodname="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="764416296" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000048" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1118" name="TryDecodeSaveSettings_ExportDtoJson_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_ExportDtoJson_Works" methodname="TryDecodeSaveSettings_ExportDtoJson_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="158641151" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000807" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1116" name="TryDecodeSaveSettings_Idb1Binary_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_Idb1Binary_Works" methodname="TryDecodeSaveSettings_Idb1Binary_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1506117177" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000693" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1119" name="TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" methodname="TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="2136111771" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000972" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1117" name="TryDecodeSaveSettings_RawJson_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_RawJson_Works" methodname="TryDecodeSaveSettings_RawJson_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1300822995" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000903" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1120" name="SaveSystemTests" fullname="Tests.Save.SaveSystemTests" classname="Tests.Save.SaveSystemTests" runstate="Runnable" testcasecount="1" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002310" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1121" name="SaveThenLoad_RoundTripsSettings" fullname="Tests.Save.SaveSystemTests.SaveThenLoad_RoundTripsSettings" methodname="SaveThenLoad_RoundTripsSettings" classname="Tests.Save.SaveSystemTests" runstate="Runnable" seed="1826130094" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001241" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1130" name="Services" fullname="Tests.Services" runstate="Runnable" testcasecount="29" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.004430" total="29" passed="29" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1067" name="ServiceLayerExampleTests" fullname="Tests.Services.ServiceLayerExampleTests" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" testcasecount="9" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000999" total="9" passed="9" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1076" name="Example_TestingPresenterLogic" fullname="Tests.Services.ServiceLayerExampleTests.Example_TestingPresenterLogic" methodname="Example_TestingPresenterLogic" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="687745283" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000056" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1075" name="InfinityData_CanBeModified" fullname="Tests.Services.ServiceLayerExampleTests.InfinityData_CanBeModified" methodname="InfinityData_CanBeModified" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1821045058" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000035" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1074" name="PrestigeData_IsAccessible" fullname="Tests.Services.ServiceLayerExampleTests.PrestigeData_IsAccessible" methodname="PrestigeData_IsAccessible" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="47960525" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000034" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1072" name="ResearchBuyMode_CanBeConfigured" fullname="Tests.Services.ServiceLayerExampleTests.ResearchBuyMode_CanBeConfigured" methodname="ResearchBuyMode_CanBeConfigured" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="286551985" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1071" name="ResearchLevel_CanBeSetAndRetrieved" fullname="Tests.Services.ServiceLayerExampleTests.ResearchLevel_CanBeSetAndRetrieved" methodname="ResearchLevel_CanBeSetAndRetrieved" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1492799353" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000034" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1070" name="ResearchLevel_DefaultsToZero" fullname="Tests.Services.ServiceLayerExampleTests.ResearchLevel_DefaultsToZero" methodname="ResearchLevel_DefaultsToZero" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1458678513" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1073" name="RoundedBulkBuy_CanBeConfigured" fullname="Tests.Services.ServiceLayerExampleTests.RoundedBulkBuy_CanBeConfigured" methodname="RoundedBulkBuy_CanBeConfigured" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="2073790589" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1069" name="Science_CanBeModified" fullname="Tests.Services.ServiceLayerExampleTests.Science_CanBeModified" methodname="Science_CanBeModified" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="983053340" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1068" name="Science_CanBeSetAndRetrieved" fullname="Tests.Services.ServiceLayerExampleTests.Science_CanBeSetAndRetrieved" methodname="Science_CanBeSetAndRetrieved" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="754738644" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1077" name="WorkerServiceTests" fullname="Tests.Services.WorkerServiceTests" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" testcasecount="20" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002275" total="20" passed="20" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1082" name="ApplyOfflineProgress_WithAutoGather_AddsToInfluence" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithAutoGather_AddsToInfluence" methodname="ApplyOfflineProgress_WithAutoGather_AddsToInfluence" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="986341798" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1083" name="ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" methodname="ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="683821023" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1084" name="ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" methodname="ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="750364820" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1085" name="ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" methodname="ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1238266546" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1095" name="CanGather_WhenFull_ReturnsTrue" fullname="Tests.Services.WorkerServiceTests.CanGather_WhenFull_ReturnsTrue" methodname="CanGather_WhenFull_ReturnsTrue" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="943106021" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000019" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1096" name="CanGather_WhenNotFull_ReturnsFalse" fullname="Tests.Services.WorkerServiceTests.CanGather_WhenNotFull_ReturnsFalse" methodname="CanGather_WhenNotFull_ReturnsFalse" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="321414629" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1093" name="ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" fullname="Tests.Services.WorkerServiceTests.ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" methodname="ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="696962775" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1094" name="ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" fullname="Tests.Services.WorkerServiceTests.ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" methodname="ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="941438819" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1092" name="IncrementWorker_IncreasesBatchesProcessed" fullname="Tests.Services.WorkerServiceTests.IncrementWorker_IncreasesBatchesProcessed" methodname="IncrementWorker_IncreasesBatchesProcessed" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1049827876" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1091" name="IncrementWorker_IncreasesWorkerCount" fullname="Tests.Services.WorkerServiceTests.IncrementWorker_IncreasesWorkerCount" methodname="IncrementWorker_IncreasesWorkerCount" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1298520666" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000020" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1081" name="TryGatherInfluence_FiresEvent" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_FiresEvent" methodname="TryGatherInfluence_FiresEvent" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1975227194" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1078" name="TryGatherInfluence_WithFullBatch_Succeeds" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithFullBatch_Succeeds" methodname="TryGatherInfluence_WithFullBatch_Succeeds" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="526880913" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1079" name="TryGatherInfluence_WithPartialBatch_Fails" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithPartialBatch_Fails" methodname="TryGatherInfluence_WithPartialBatch_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="800373040" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1080" name="TryGatherInfluence_WithZeroWorkers_Fails" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithZeroWorkers_Fails" methodname="TryGatherInfluence_WithZeroWorkers_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1088910147" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1090" name="TrySpendInfluence_FiresEvent" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_FiresEvent" methodname="TrySpendInfluence_FiresEvent" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1751739349" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1087" name="TrySpendInfluence_WithInsufficientBalance_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithInsufficientBalance_Fails" methodname="TrySpendInfluence_WithInsufficientBalance_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="244442496" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1089" name="TrySpendInfluence_WithNegativeAmount_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithNegativeAmount_Fails" methodname="TrySpendInfluence_WithNegativeAmount_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1018724354" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1086" name="TrySpendInfluence_WithSufficientBalance_Succeeds" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithSufficientBalance_Succeeds" methodname="TrySpendInfluence_WithSufficientBalance_Succeeds" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1266049746" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1088" name="TrySpendInfluence_WithZeroAmount_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithZeroAmount_Fails" methodname="TrySpendInfluence_WithZeroAmount_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="273053543" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1097" name="WorkerFillPercent_CalculatesCorrectly" fullname="Tests.Services.WorkerServiceTests.WorkerFillPercent_CalculatesCorrectly" methodname="WorkerFillPercent_CalculatesCorrectly" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="767827641" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1129" name="Systems" fullname="Tests.Systems" runstate="Runnable" testcasecount="55" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.019199" total="55" passed="55" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1005" name="FacilityCountAccessorTests" fullname="Tests.Systems.FacilityCountAccessorTests" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" testcasecount="21" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001960" total="21" passed="21" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1026" name="AllFacilities_RoundTrip_ProducesConsistentResults" fullname="Tests.Systems.FacilityCountAccessorTests.AllFacilities_RoundTrip_ProducesConsistentResults" methodname="AllFacilities_RoundTrip_ProducesConsistentResults" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="120775296" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000056" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1024" name="IsKnownFacility_NullOrEmpty_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_NullOrEmpty_ReturnsFalse" methodname="IsKnownFacility_NullOrEmpty_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="364442989" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1023" name="IsKnownFacility_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_UnknownFacility_ReturnsFalse" methodname="IsKnownFacility_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="310061681" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000034" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1022" name="IsKnownFacility_ValidFacilities_ReturnsTrue" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_ValidFacilities_ReturnsTrue" methodname="IsKnownFacility_ValidFacilities_ReturnsTrue" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1903991323" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1025" name="SetThenGet_ProducesConsistentResults" fullname="Tests.Systems.FacilityCountAccessorTests.SetThenGet_ProducesConsistentResults" methodname="SetThenGet_ProducesConsistentResults" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="157148808" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000038" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1007" name="TryGetCount_AiManagers_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_AiManagers_ReturnsCorrectArray" methodname="TryGetCount_AiManagers_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1883657379" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1006" name="TryGetCount_AssemblyLines_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_AssemblyLines_ReturnsCorrectArray" methodname="TryGetCount_AssemblyLines_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="318562152" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1009" name="TryGetCount_DataCenters_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_DataCenters_ReturnsCorrectArray" methodname="TryGetCount_DataCenters_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="21711060" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1014" name="TryGetCount_EmptyFacilityId_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_EmptyFacilityId_ReturnsFalse" methodname="TryGetCount_EmptyFacilityId_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1913992594" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1012" name="TryGetCount_NullData_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_NullData_ReturnsFalse" methodname="TryGetCount_NullData_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1064906381" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1013" name="TryGetCount_NullFacilityId_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_NullFacilityId_ReturnsFalse" methodname="TryGetCount_NullFacilityId_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="615905688" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1010" name="TryGetCount_Planets_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_Planets_ReturnsCorrectArray" methodname="TryGetCount_Planets_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1941043985" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1008" name="TryGetCount_Servers_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_Servers_ReturnsCorrectArray" methodname="TryGetCount_Servers_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1854182711" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1011" name="TryGetCount_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_UnknownFacility_ReturnsFalse" methodname="TryGetCount_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1490885433" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1016" name="TrySetCount_AiManagers_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_AiManagers_SetsCorrectValues" methodname="TrySetCount_AiManagers_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="134999359" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1015" name="TrySetCount_AssemblyLines_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_AssemblyLines_SetsCorrectValues" methodname="TrySetCount_AssemblyLines_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="2015793594" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1018" name="TrySetCount_DataCenters_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_DataCenters_SetsCorrectValues" methodname="TrySetCount_DataCenters_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1028123534" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1021" name="TrySetCount_NullData_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_NullData_ReturnsFalse" methodname="TrySetCount_NullData_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="597088199" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1019" name="TrySetCount_Planets_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_Planets_SetsCorrectValues" methodname="TrySetCount_Planets_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1195360829" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1017" name="TrySetCount_Servers_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_Servers_SetsCorrectValues" methodname="TrySetCount_Servers_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1615877954" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1020" name="TrySetCount_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_UnknownFacility_ReturnsFalse" methodname="TrySetCount_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="430567032" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1027" name="ModifierSystemTests" fullname="Tests.Systems.ModifierSystemTests" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002407" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1041" name="BuildSecretBuffState_DoesNotModifyInfinityData" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_DoesNotModifyInfinityData" methodname="BuildSecretBuffState_DoesNotModifyInfinityData" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1558479059" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000033" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1038" name="BuildSecretBuffState_Level0_ReturnsDefaultState" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_Level0_ReturnsDefaultState" methodname="BuildSecretBuffState_Level0_ReturnsDefaultState" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1102746519" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1039" name="BuildSecretBuffState_Level27_ReturnsMaxMultipliers" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_Level27_ReturnsMaxMultipliers" methodname="BuildSecretBuffState_Level27_ReturnsMaxMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="340286484" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1040" name="BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" methodname="BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="963154943" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1042" name="SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" methodname="SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1948024368" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000307" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1028" name="SecretBuffs_Level0_ReturnsDefaultMultipliers" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level0_ReturnsDefaultMultipliers" methodname="SecretBuffs_Level0_ReturnsDefaultMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="2022992929" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000034" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1029" name="SecretBuffs_Level1_AppliesOnlyFirstBuff" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level1_AppliesOnlyFirstBuff" methodname="SecretBuffs_Level1_AppliesOnlyFirstBuff" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="2008527061" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1032" name="SecretBuffs_Level10_OverwritesScienceMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level10_OverwritesScienceMultiplier" methodname="SecretBuffs_Level10_OverwritesScienceMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1788453150" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1030" name="SecretBuffs_Level2_AppliesCashMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level2_AppliesCashMultiplier" methodname="SecretBuffs_Level2_AppliesCashMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1698734806" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1033" name="SecretBuffs_Level20_AppliesServerMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level20_AppliesServerMultiplier" methodname="SecretBuffs_Level20_AppliesServerMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1812854290" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1035" name="SecretBuffs_Level27_AppliesAllUpgradePercents" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level27_AppliesAllUpgradePercents" methodname="SecretBuffs_Level27_AppliesAllUpgradePercents" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="51211395" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1034" name="SecretBuffs_Level27_AppliesMaxAiMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level27_AppliesMaxAiMultiplier" methodname="SecretBuffs_Level27_AppliesMaxAiMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="580493828" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1031" name="SecretBuffs_Level6_AppliesScienceMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level6_AppliesScienceMultiplier" methodname="SecretBuffs_Level6_AppliesScienceMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="905868231" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1036" name="SecretBuffs_NullPrestigeData_DoesNotThrow" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_NullPrestigeData_DoesNotThrow" methodname="SecretBuffs_NullPrestigeData_DoesNotThrow" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1487662416" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1037" name="SecretBuffs_NullSecrets_DoesNotThrow" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_NullSecrets_DoesNotThrow" methodname="SecretBuffs_NullSecrets_DoesNotThrow" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="165214346" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1043" name="OfflineAwayTimeCalculatorTests" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" testcasecount="6" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001305" total="6" passed="6" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1049" name="Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" methodname="Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1589899617" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000037" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1047" name="Compute_InvalidQuitAndStarted_UsesRuntimeFallback" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_InvalidQuitAndStarted_UsesRuntimeFallback" methodname="Compute_InvalidQuitAndStarted_UsesRuntimeFallback" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="222073731" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000043" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1046" name="Compute_InvalidQuitString_FallsBackToDateStarted" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_InvalidQuitString_FallsBackToDateStarted" methodname="Compute_InvalidQuitString_FallsBackToDateStarted" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1290481915" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1044" name="Compute_MissingQuitString_ReturnsMissingSourceAndZero" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_MissingQuitString_ReturnsMissingSourceAndZero" methodname="Compute_MissingQuitString_ReturnsMissingSourceAndZero" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="564921322" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1048" name="Compute_OffsetTimestamp_ParsesAsUtc" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_OffsetTimestamp_ParsesAsUtc" methodname="Compute_OffsetTimestamp_ParsesAsUtc" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1247578223" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1045" name="Compute_ValidQuitString_UsesQuitTimestamp" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_ValidQuitString_UsesQuitTimestamp" methodname="Compute_ValidQuitString_UsesQuitTimestamp" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="411833309" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1050" name="OfflineLifecycleCoordinatorTests" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001211" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1055" name="Dispose_UnsubscribesFromEvents" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.Dispose_UnsubscribesFromEvents" methodname="Dispose_UnsubscribesFromEvents" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="639284871" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1054" name="FocusGainReloadEnabled_ReloadsOnEachFocusGain" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.FocusGainReloadEnabled_ReloadsOnEachFocusGain" methodname="FocusGainReloadEnabled_ReloadsOnEachFocusGain" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="698146548" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000020" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1051" name="FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" methodname="FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="647600194" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000033" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1052" name="PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" methodname="PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="45761851" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1053" name="RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" methodname="RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="204452098" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1056" name="OfflinePersistenceRegressionTests" fullname="Tests.Systems.OfflinePersistenceRegressionTests" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" testcasecount="3" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.007428" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-suite type="ParameterizedMethod" id="1060" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" testcasecount="3" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.006459" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties />
+              <test-case id="1057" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(120.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(120.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="748517227" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.002203" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=0, afterOfflineTime=120, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=60.000, applied=60.000, beforeOfflineTime=120, afterOfflineTime=180, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+              <test-case id="1058" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(900.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(900.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="962056478" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001986" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=900.000, applied=900.000, beforeOfflineTime=0, afterOfflineTime=900, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=450.000, applied=450.000, beforeOfflineTime=900, afterOfflineTime=1350, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+              <test-case id="1059" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(3600.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(3600.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="442706677" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.001864" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=3600.000, applied=3600.000, beforeOfflineTime=0, afterOfflineTime=3600, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=1800.000, applied=1800.000, beforeOfflineTime=3600, afterOfflineTime=5400, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+            </test-suite>
+          </test-suite>
+          <test-suite type="TestFixture" id="1061" name="OfflineProgressSystemTests" fullname="Tests.Systems.OfflineProgressSystemTests" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.003398" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1064" name="ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" methodname="ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1323828661" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000321" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=300.000, applied=100.000, beforeOfflineTime=500, afterOfflineTime=600, capApplied=true, maxOfflineTime=600
+]]></output>
+            </test-case>
+            <test-case id="1065" name="ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" methodname="ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="656831963" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000295" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=cheater_reset, awayRaw=-5.000, beforeOfflineTime=200, afterOfflineTime=0, maxOfflineTime=0
+]]></output>
+            </test-case>
+            <test-case id="1062" name="ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" methodname="ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1672070449" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000294" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=30, afterOfflineTime=150, capApplied=false, maxOfflineTime=600
+]]></output>
+            </test-case>
+            <test-case id="1066" name="ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" methodname="ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1577217179" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000578" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=0, afterOfflineTime=120, capApplied=false, maxOfflineTime=1000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=300.000, applied=300.000, beforeOfflineTime=120, afterOfflineTime=420, capApplied=false, maxOfflineTime=1000
+]]></output>
+            </test-case>
+            <test-case id="1063" name="ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" methodname="ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1468790500" result="Passed" start-time="2026-02-16 00:13:03Z" end-time="2026-02-16 00:13:03Z" duration="0.000284" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=0.000, applied=0.000, beforeOfflineTime=45, afterOfflineTime=45, capApplied=false, maxOfflineTime=600
+Saving results to: /Users/matthewrushworth/Library/Application Support/BlindsidedGames/Idle Dyson Swarm/TestResults.xml
+]]></output>
+            </test-case>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/Documentation/Test Results/TestResults_20260216_111859.xml
+++ b/Documentation/Test Results/TestResults_20260216_111859.xml
@@ -1,0 +1,807 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="2" testcasecount="106" result="Failed(Child)" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.104205">
+  <test-suite type="TestSuite" id="1134" name="Idle Dyson Swarm" fullname="Idle Dyson Swarm" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.104205" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+    <properties>
+      <property name="platform" value="EditMode" />
+    </properties>
+    <failure>
+      <message><![CDATA[One or more child tests had errors]]></message>
+    </failure>
+    <test-suite type="Assembly" id="1123" name="Assembly-CSharp-Editor.dll" fullname="/Users/matthewrushworth/Projects/Idle Dyson Swarm/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.101803" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_PID" value="10104" />
+        <property name="_APPDOMAIN" value="Unity Child Domain" />
+        <property name="platform" value="EditMode" />
+        <property name="EditorOnly" value="True" />
+      </properties>
+      <failure>
+        <message><![CDATA[One or more child tests had errors]]></message>
+      </failure>
+      <test-suite type="TestSuite" id="1124" name="Tests" fullname="Tests" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.100983" total="106" passed="102" failed="4" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <failure>
+          <message><![CDATA[One or more child tests had errors]]></message>
+        </failure>
+        <test-suite type="TestSuite" id="1128" name="Investigations" fullname="Tests.Investigations" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.018384" total="4" passed="0" failed="4" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <failure>
+            <message><![CDATA[One or more child tests had errors]]></message>
+          </failure>
+          <test-suite type="TestFixture" id="1118" name="ProductionUiMismatchTests" fullname="Tests.Investigations.ProductionUiMismatchTests" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.017977" total="4" passed="0" failed="4" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <failure>
+              <message><![CDATA[One or more child tests had errors]]></message>
+            </failure>
+            <test-case id="1121" name="DataCenters_Control_NoRudimentary_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_Control_NoRudimentary_ParityHolds" methodname="DataCenters_Control_NoRudimentary_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="2012177896" result="Failed" label="Error" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.016522" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculateDataCenterModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x000ac] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:270 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000c8] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:210 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculateDataCenterProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double deltaTime) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:182 
+  at Tests.Investigations.ProductionUiMismatchTests.DataCenters_Control_NoRudimentary_ParityHolds () [0x0003f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:95 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1119" name="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate" methodname="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="1562714387" result="Failed" label="Error" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000270" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculateDataCenterModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x000ac] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:270 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000c8] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:210 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculateDataCenterProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, System.Double deltaTime) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:182 
+  at Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate () [0x0004e] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:49 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1122" name="Planets_Control_NoPocketDimensions_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_Control_NoPocketDimensions_ParityHolds" methodname="Planets_Control_NoPocketDimensions_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="597806853" result="Failed" label="Error" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000220" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculatePlanetModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.SecretBuffState secrets, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x00217] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:344 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000dc] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:213 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculatePlanetProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, System.Double deltaTime) [0x00065] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:120 
+  at Tests.Investigations.ProductionUiMismatchTests.Planets_Control_NoPocketDimensions_ParityHolds () [0x00047] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:118 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1120" name="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" methodname="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="1724238628" result="Failed" label="Error" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000219" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object]]></message>
+                <stack-trace><![CDATA[  at Systems.Stats.FacilityModifierPipeline.AddAvocatoMultiplier (System.Collections.Generic.List`1[T] effects, System.String statId, Expansion.Oracle+PrestigePlus prestigePlus, System.String id, System.Int32 order) [0x00000] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:531 
+  at Systems.Stats.FacilityModifierPipeline.TryCalculatePlanetModifier (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.SecretBuffState secrets, System.Double maxInfinityBuff, Systems.Stats.StatResult& result) [0x00217] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Stats/FacilityModifierPipeline.cs:344 
+  at Systems.Facilities.FacilityEffectPipeline.TryBuildModifierResult (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, Systems.Stats.StatResult& result) [0x000dc] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:213 
+  at Systems.Facilities.FacilityEffectPipeline.BuildModifierEffects (GameData.FacilityDefinition definition, Systems.Stats.EffectContext context, System.String displayName) [0x0001a] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:61 
+  at Systems.Facilities.FacilityEffectPipeline.BuildProductionEffects (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x0009f] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:47 
+  at Systems.Facilities.FacilityEffectPipeline.BuildRuntimeFromDefinitions (GameData.FacilityDefinition definition, Systems.Facilities.FacilityState state, Systems.Stats.EffectContext context) [0x00015] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityEffectPipeline.cs:21 
+  at Systems.Facilities.FacilityRuntimeBuilder.TryBuildRuntime (System.String facilityId, Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVersePrestigeData prestigeData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+PrestigePlus prestigePlus, Systems.Facilities.FacilityRuntime& runtime) [0x00046] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/Facilities/FacilityRuntimeBuilder.cs:38 
+  at Systems.ProductionSystem.CalculatePlanetProduction (Expansion.Oracle+DysonVerseInfinityData infinityData, Expansion.Oracle+DysonVerseSkillTreeData skillTreeData, Expansion.Oracle+DysonVersePrestigeData prestigeData, System.Double deltaTime) [0x00065] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Scripts/Systems/ProductionSystem.cs:120 
+  at Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate () [0x00047] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:72 
+  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
+  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <032c206a1674455bacfc3546f1de5ef3>:0 ]]></stack-trace>
+              </failure>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1127" name="Save" fullname="Tests.Save" runstate="Runnable" testcasecount="18" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.037527" total="18" passed="18" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1094" name="CanonicalSaveStoreTests" fullname="Tests.Save.CanonicalSaveStoreTests" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002805" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1095" name="TrySaveThenTryLoad_RoundTripsCanonicalSettings" fullname="Tests.Save.CanonicalSaveStoreTests.TrySaveThenTryLoad_RoundTripsCanonicalSettings" methodname="TrySaveThenTryLoad_RoundTripsCanonicalSettings" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" seed="92081281" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000871" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1096" name="TrySaveTwice_TryLoadReturnsLatestSnapshot" fullname="Tests.Save.CanonicalSaveStoreTests.TrySaveTwice_TryLoadReturnsLatestSnapshot" methodname="TrySaveTwice_TryLoadReturnsLatestSnapshot" classname="Tests.Save.CanonicalSaveStoreTests" runstate="Runnable" seed="431987438" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.001234" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1097" name="FacilityArrayNormalizerTests" fullname="Tests.Save.FacilityArrayNormalizerTests" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002250" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1102" name="ClearSparseLists_SetsAllSparseListsToNull" fullname="Tests.Save.FacilityArrayNormalizerTests.ClearSparseLists_SetsAllSparseListsToNull" methodname="ClearSparseLists_SetsAllSparseListsToNull" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="731600045" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1100" name="EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" fullname="Tests.Save.FacilityArrayNormalizerTests.EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" methodname="EnsureDenseArraysAndMergeSparse_UsesMaxPerSlot" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="472109098" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1101" name="EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" fullname="Tests.Save.FacilityArrayNormalizerTests.EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" methodname="EnsureDenseArraysAndMergeSparse_WhenDenseWrongLength_EnsuresTwoSlots" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="1024559215" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1099" name="Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" fullname="Tests.Save.FacilityArrayNormalizerTests.Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" methodname="Normalize_WithDenseNullAndSparsePresent_RestoresDenseAndClearsSparse" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="145717215" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1098" name="Normalize_WithNullData_DoesNotThrow" fullname="Tests.Save.FacilityArrayNormalizerTests.Normalize_WithNullData_DoesNotThrow" methodname="Normalize_WithNullData_DoesNotThrow" classname="Tests.Save.FacilityArrayNormalizerTests" runstate="Runnable" seed="1386099674" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000016" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1103" name="OdinStringFileStorageTests" fullname="Tests.Save.OdinStringFileStorageTests" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.003097" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1104" name="WriteAndRead_RoundTripsText_AndCreatesBackups" fullname="Tests.Save.OdinStringFileStorageTests.WriteAndRead_RoundTripsText_AndCreatesBackups" methodname="WriteAndRead_RoundTripsText_AndCreatesBackups" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" seed="1121498273" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.001384" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1105" name="WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" fullname="Tests.Save.OdinStringFileStorageTests.WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" methodname="WriteAtomic_WithEmptyText_DoesNotOverwriteExisting" classname="Tests.Save.OdinStringFileStorageTests" runstate="Runnable" seed="574287264" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000298" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1106" name="SaveCodecCharacterizationTests" fullname="Tests.Save.SaveCodecCharacterizationTests" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" testcasecount="2" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.011295" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1107" name="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" fullname="Tests.Save.SaveCodecCharacterizationTests.EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" methodname="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBinaryPayload" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" seed="1021482402" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.009681" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1108" name="EncodeBinary_CompressTrue_UsesGzipHeader" fullname="Tests.Save.SaveCodecCharacterizationTests.EncodeBinary_CompressTrue_UsesGzipHeader" methodname="EncodeBinary_CompressTrue_UsesGzipHeader" classname="Tests.Save.SaveCodecCharacterizationTests" runstate="Runnable" seed="1701881502" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000042" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1109" name="SaveCodecTests" fullname="Tests.Save.SaveCodecTests" classname="Tests.Save.SaveCodecTests" runstate="Runnable" testcasecount="6" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.006077" total="6" passed="6" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1111" name="EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" fullname="Tests.Save.SaveCodecTests.EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" methodname="EncodeBinary_CompressFalse_TryDecodeBinary_RoundTripsBytes" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="19972415" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1110" name="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" fullname="Tests.Save.SaveCodecTests.EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" methodname="EncodeBinary_CompressTrue_TryDecodeBinary_RoundTripsBytes" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="757884679" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000053" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1114" name="TryDecodeSaveSettings_ExportDtoJson_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_ExportDtoJson_Works" methodname="TryDecodeSaveSettings_ExportDtoJson_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1824196947" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000778" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1112" name="TryDecodeSaveSettings_Idb1Binary_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_Idb1Binary_Works" methodname="TryDecodeSaveSettings_Idb1Binary_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1663660820" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000671" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1115" name="TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" methodname="TryDecodeSaveSettings_LegacyBase64OfGzippedBinary_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1131025497" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000979" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1113" name="TryDecodeSaveSettings_RawJson_Works" fullname="Tests.Save.SaveCodecTests.TryDecodeSaveSettings_RawJson_Works" methodname="TryDecodeSaveSettings_RawJson_Works" classname="Tests.Save.SaveCodecTests" runstate="Runnable" seed="1345001657" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000991" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1116" name="SaveSystemTests" fullname="Tests.Save.SaveSystemTests" classname="Tests.Save.SaveSystemTests" runstate="Runnable" testcasecount="1" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.003571" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1117" name="SaveThenLoad_RoundTripsSettings" fullname="Tests.Save.SaveSystemTests.SaveThenLoad_RoundTripsSettings" methodname="SaveThenLoad_RoundTripsSettings" classname="Tests.Save.SaveSystemTests" runstate="Runnable" seed="244630736" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.001354" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1126" name="Services" fullname="Tests.Services" runstate="Runnable" testcasecount="29" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.009636" total="29" passed="29" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1063" name="ServiceLayerExampleTests" fullname="Tests.Services.ServiceLayerExampleTests" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" testcasecount="9" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002446" total="9" passed="9" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1072" name="Example_TestingPresenterLogic" fullname="Tests.Services.ServiceLayerExampleTests.Example_TestingPresenterLogic" methodname="Example_TestingPresenterLogic" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1683700393" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000043" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1071" name="InfinityData_CanBeModified" fullname="Tests.Services.ServiceLayerExampleTests.InfinityData_CanBeModified" methodname="InfinityData_CanBeModified" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1169659572" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000044" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1070" name="PrestigeData_IsAccessible" fullname="Tests.Services.ServiceLayerExampleTests.PrestigeData_IsAccessible" methodname="PrestigeData_IsAccessible" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="423265407" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1068" name="ResearchBuyMode_CanBeConfigured" fullname="Tests.Services.ServiceLayerExampleTests.ResearchBuyMode_CanBeConfigured" methodname="ResearchBuyMode_CanBeConfigured" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1957070367" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000038" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1067" name="ResearchLevel_CanBeSetAndRetrieved" fullname="Tests.Services.ServiceLayerExampleTests.ResearchLevel_CanBeSetAndRetrieved" methodname="ResearchLevel_CanBeSetAndRetrieved" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="250756920" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1066" name="ResearchLevel_DefaultsToZero" fullname="Tests.Services.ServiceLayerExampleTests.ResearchLevel_DefaultsToZero" methodname="ResearchLevel_DefaultsToZero" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1599253161" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1069" name="RoundedBulkBuy_CanBeConfigured" fullname="Tests.Services.ServiceLayerExampleTests.RoundedBulkBuy_CanBeConfigured" methodname="RoundedBulkBuy_CanBeConfigured" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="684512842" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1065" name="Science_CanBeModified" fullname="Tests.Services.ServiceLayerExampleTests.Science_CanBeModified" methodname="Science_CanBeModified" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="49381677" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1064" name="Science_CanBeSetAndRetrieved" fullname="Tests.Services.ServiceLayerExampleTests.Science_CanBeSetAndRetrieved" methodname="Science_CanBeSetAndRetrieved" classname="Tests.Services.ServiceLayerExampleTests" runstate="Runnable" seed="1699536724" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1073" name="WorkerServiceTests" fullname="Tests.Services.WorkerServiceTests" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" testcasecount="20" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.005574" total="20" passed="20" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1078" name="ApplyOfflineProgress_WithAutoGather_AddsToInfluence" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithAutoGather_AddsToInfluence" methodname="ApplyOfflineProgress_WithAutoGather_AddsToInfluence" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="750162727" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1079" name="ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" methodname="ApplyOfflineProgress_WithManualGather_AccumulatesWorkers" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="512056981" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000025" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1080" name="ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" methodname="ApplyOfflineProgress_WithManualGather_CapsAtBatchSize" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="288040095" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1081" name="ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" fullname="Tests.Services.WorkerServiceTests.ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" methodname="ApplyOfflineProgress_WithPartialWorkers_AccumulatesCorrectly" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="217199259" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1091" name="CanGather_WhenFull_ReturnsTrue" fullname="Tests.Services.WorkerServiceTests.CanGather_WhenFull_ReturnsTrue" methodname="CanGather_WhenFull_ReturnsTrue" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="909199955" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1092" name="CanGather_WhenNotFull_ReturnsFalse" fullname="Tests.Services.WorkerServiceTests.CanGather_WhenNotFull_ReturnsFalse" methodname="CanGather_WhenNotFull_ReturnsFalse" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="84386054" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1089" name="ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" fullname="Tests.Services.WorkerServiceTests.ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" methodname="ClampWorkersNonNegative_WithNegativeWorkers_ClampsToZero" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1254256646" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1090" name="ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" fullname="Tests.Services.WorkerServiceTests.ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" methodname="ClampWorkersNonNegative_WithPositiveWorkers_DoesNotChange" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1821878680" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1088" name="IncrementWorker_IncreasesBatchesProcessed" fullname="Tests.Services.WorkerServiceTests.IncrementWorker_IncreasesBatchesProcessed" methodname="IncrementWorker_IncreasesBatchesProcessed" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="135253705" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1087" name="IncrementWorker_IncreasesWorkerCount" fullname="Tests.Services.WorkerServiceTests.IncrementWorker_IncreasesWorkerCount" methodname="IncrementWorker_IncreasesWorkerCount" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="2025430136" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000020" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1077" name="TryGatherInfluence_FiresEvent" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_FiresEvent" methodname="TryGatherInfluence_FiresEvent" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1039602047" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1074" name="TryGatherInfluence_WithFullBatch_Succeeds" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithFullBatch_Succeeds" methodname="TryGatherInfluence_WithFullBatch_Succeeds" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1723606346" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000020" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1075" name="TryGatherInfluence_WithPartialBatch_Fails" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithPartialBatch_Fails" methodname="TryGatherInfluence_WithPartialBatch_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1226574823" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1076" name="TryGatherInfluence_WithZeroWorkers_Fails" fullname="Tests.Services.WorkerServiceTests.TryGatherInfluence_WithZeroWorkers_Fails" methodname="TryGatherInfluence_WithZeroWorkers_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="308192318" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1086" name="TrySpendInfluence_FiresEvent" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_FiresEvent" methodname="TrySpendInfluence_FiresEvent" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1877894196" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1083" name="TrySpendInfluence_WithInsufficientBalance_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithInsufficientBalance_Fails" methodname="TrySpendInfluence_WithInsufficientBalance_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1169969740" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1085" name="TrySpendInfluence_WithNegativeAmount_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithNegativeAmount_Fails" methodname="TrySpendInfluence_WithNegativeAmount_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1472919010" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000020" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1082" name="TrySpendInfluence_WithSufficientBalance_Succeeds" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithSufficientBalance_Succeeds" methodname="TrySpendInfluence_WithSufficientBalance_Succeeds" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="1764790387" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000021" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1084" name="TrySpendInfluence_WithZeroAmount_Fails" fullname="Tests.Services.WorkerServiceTests.TrySpendInfluence_WithZeroAmount_Fails" methodname="TrySpendInfluence_WithZeroAmount_Fails" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="663001054" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1093" name="WorkerFillPercent_CalculatesCorrectly" fullname="Tests.Services.WorkerServiceTests.WorkerFillPercent_CalculatesCorrectly" methodname="WorkerFillPercent_CalculatesCorrectly" classname="Tests.Services.WorkerServiceTests" runstate="Runnable" seed="871808370" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+        </test-suite>
+        <test-suite type="TestSuite" id="1125" name="Systems" fullname="Tests.Systems" runstate="Runnable" testcasecount="55" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.033963" total="55" passed="55" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <test-suite type="TestFixture" id="1001" name="FacilityCountAccessorTests" fullname="Tests.Systems.FacilityCountAccessorTests" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" testcasecount="21" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.005191" total="21" passed="21" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1022" name="AllFacilities_RoundTrip_ProducesConsistentResults" fullname="Tests.Systems.FacilityCountAccessorTests.AllFacilities_RoundTrip_ProducesConsistentResults" methodname="AllFacilities_RoundTrip_ProducesConsistentResults" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="303699289" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000057" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1020" name="IsKnownFacility_NullOrEmpty_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_NullOrEmpty_ReturnsFalse" methodname="IsKnownFacility_NullOrEmpty_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1299063826" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000035" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1019" name="IsKnownFacility_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_UnknownFacility_ReturnsFalse" methodname="IsKnownFacility_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1958073928" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1018" name="IsKnownFacility_ValidFacilities_ReturnsTrue" fullname="Tests.Systems.FacilityCountAccessorTests.IsKnownFacility_ValidFacilities_ReturnsTrue" methodname="IsKnownFacility_ValidFacilities_ReturnsTrue" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="727246581" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1021" name="SetThenGet_ProducesConsistentResults" fullname="Tests.Systems.FacilityCountAccessorTests.SetThenGet_ProducesConsistentResults" methodname="SetThenGet_ProducesConsistentResults" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1614319626" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1003" name="TryGetCount_AiManagers_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_AiManagers_ReturnsCorrectArray" methodname="TryGetCount_AiManagers_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="494027397" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1002" name="TryGetCount_AssemblyLines_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_AssemblyLines_ReturnsCorrectArray" methodname="TryGetCount_AssemblyLines_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1123542873" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1005" name="TryGetCount_DataCenters_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_DataCenters_ReturnsCorrectArray" methodname="TryGetCount_DataCenters_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1262168677" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000028" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1010" name="TryGetCount_EmptyFacilityId_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_EmptyFacilityId_ReturnsFalse" methodname="TryGetCount_EmptyFacilityId_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1728726754" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1008" name="TryGetCount_NullData_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_NullData_ReturnsFalse" methodname="TryGetCount_NullData_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="25607935" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1009" name="TryGetCount_NullFacilityId_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_NullFacilityId_ReturnsFalse" methodname="TryGetCount_NullFacilityId_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="505802727" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1006" name="TryGetCount_Planets_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_Planets_ReturnsCorrectArray" methodname="TryGetCount_Planets_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1945495802" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1004" name="TryGetCount_Servers_ReturnsCorrectArray" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_Servers_ReturnsCorrectArray" methodname="TryGetCount_Servers_ReturnsCorrectArray" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="297294322" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1007" name="TryGetCount_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TryGetCount_UnknownFacility_ReturnsFalse" methodname="TryGetCount_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1691206740" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000022" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1012" name="TrySetCount_AiManagers_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_AiManagers_SetsCorrectValues" methodname="TrySetCount_AiManagers_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="785516888" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1011" name="TrySetCount_AssemblyLines_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_AssemblyLines_SetsCorrectValues" methodname="TrySetCount_AssemblyLines_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1785597446" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1014" name="TrySetCount_DataCenters_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_DataCenters_SetsCorrectValues" methodname="TrySetCount_DataCenters_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="91892" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000035" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1017" name="TrySetCount_NullData_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_NullData_ReturnsFalse" methodname="TrySetCount_NullData_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="478614743" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1015" name="TrySetCount_Planets_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_Planets_SetsCorrectValues" methodname="TrySetCount_Planets_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1462260350" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1013" name="TrySetCount_Servers_SetsCorrectValues" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_Servers_SetsCorrectValues" methodname="TrySetCount_Servers_SetsCorrectValues" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1590623296" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1016" name="TrySetCount_UnknownFacility_ReturnsFalse" fullname="Tests.Systems.FacilityCountAccessorTests.TrySetCount_UnknownFacility_ReturnsFalse" methodname="TrySetCount_UnknownFacility_ReturnsFalse" classname="Tests.Systems.FacilityCountAccessorTests" runstate="Runnable" seed="1100650236" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1023" name="ModifierSystemTests" fullname="Tests.Systems.ModifierSystemTests" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" testcasecount="15" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.004986" total="15" passed="15" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1037" name="BuildSecretBuffState_DoesNotModifyInfinityData" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_DoesNotModifyInfinityData" methodname="BuildSecretBuffState_DoesNotModifyInfinityData" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="918243598" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1034" name="BuildSecretBuffState_Level0_ReturnsDefaultState" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_Level0_ReturnsDefaultState" methodname="BuildSecretBuffState_Level0_ReturnsDefaultState" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="874965300" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1035" name="BuildSecretBuffState_Level27_ReturnsMaxMultipliers" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_Level27_ReturnsMaxMultipliers" methodname="BuildSecretBuffState_Level27_ReturnsMaxMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="200093893" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1036" name="BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" fullname="Tests.Systems.ModifierSystemTests.BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" methodname="BuildSecretBuffState_NullPrestigeData_ReturnsDefaultState" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1564292280" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1038" name="SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" methodname="SecretBuffs_And_BuildSecretBuffState_ProduceSameMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="106727" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000280" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1024" name="SecretBuffs_Level0_ReturnsDefaultMultipliers" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level0_ReturnsDefaultMultipliers" methodname="SecretBuffs_Level0_ReturnsDefaultMultipliers" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="137922291" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1025" name="SecretBuffs_Level1_AppliesOnlyFirstBuff" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level1_AppliesOnlyFirstBuff" methodname="SecretBuffs_Level1_AppliesOnlyFirstBuff" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="772896640" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1028" name="SecretBuffs_Level10_OverwritesScienceMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level10_OverwritesScienceMultiplier" methodname="SecretBuffs_Level10_OverwritesScienceMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1203572760" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1026" name="SecretBuffs_Level2_AppliesCashMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level2_AppliesCashMultiplier" methodname="SecretBuffs_Level2_AppliesCashMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="199877851" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1029" name="SecretBuffs_Level20_AppliesServerMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level20_AppliesServerMultiplier" methodname="SecretBuffs_Level20_AppliesServerMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1554687696" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1031" name="SecretBuffs_Level27_AppliesAllUpgradePercents" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level27_AppliesAllUpgradePercents" methodname="SecretBuffs_Level27_AppliesAllUpgradePercents" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="401394190" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1030" name="SecretBuffs_Level27_AppliesMaxAiMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level27_AppliesMaxAiMultiplier" methodname="SecretBuffs_Level27_AppliesMaxAiMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1841371146" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000030" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1027" name="SecretBuffs_Level6_AppliesScienceMultiplier" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_Level6_AppliesScienceMultiplier" methodname="SecretBuffs_Level6_AppliesScienceMultiplier" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="601563154" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1032" name="SecretBuffs_NullPrestigeData_DoesNotThrow" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_NullPrestigeData_DoesNotThrow" methodname="SecretBuffs_NullPrestigeData_DoesNotThrow" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="1643819581" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000026" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1033" name="SecretBuffs_NullSecrets_DoesNotThrow" fullname="Tests.Systems.ModifierSystemTests.SecretBuffs_NullSecrets_DoesNotThrow" methodname="SecretBuffs_NullSecrets_DoesNotThrow" classname="Tests.Systems.ModifierSystemTests" runstate="Runnable" seed="118570818" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1039" name="OfflineAwayTimeCalculatorTests" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" testcasecount="6" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002844" total="6" passed="6" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1045" name="Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" methodname="Compute_FutureQuitTimestamp_ClampsNegativeAwayTimeToZero" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1349393585" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000042" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1043" name="Compute_InvalidQuitAndStarted_UsesRuntimeFallback" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_InvalidQuitAndStarted_UsesRuntimeFallback" methodname="Compute_InvalidQuitAndStarted_UsesRuntimeFallback" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="392580192" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000049" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1042" name="Compute_InvalidQuitString_FallsBackToDateStarted" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_InvalidQuitString_FallsBackToDateStarted" methodname="Compute_InvalidQuitString_FallsBackToDateStarted" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1445459566" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000032" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1040" name="Compute_MissingQuitString_ReturnsMissingSourceAndZero" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_MissingQuitString_ReturnsMissingSourceAndZero" methodname="Compute_MissingQuitString_ReturnsMissingSourceAndZero" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1864661740" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000029" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1044" name="Compute_OffsetTimestamp_ParsesAsUtc" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_OffsetTimestamp_ParsesAsUtc" methodname="Compute_OffsetTimestamp_ParsesAsUtc" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="770486429" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000023" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1041" name="Compute_ValidQuitString_UsesQuitTimestamp" fullname="Tests.Systems.OfflineAwayTimeCalculatorTests.Compute_ValidQuitString_UsesQuitTimestamp" methodname="Compute_ValidQuitString_UsesQuitTimestamp" classname="Tests.Systems.OfflineAwayTimeCalculatorTests" runstate="Runnable" seed="1353772742" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1046" name="OfflineLifecycleCoordinatorTests" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002333" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1051" name="Dispose_UnsubscribesFromEvents" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.Dispose_UnsubscribesFromEvents" methodname="Dispose_UnsubscribesFromEvents" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="910954164" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000027" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1050" name="FocusGainReloadEnabled_ReloadsOnEachFocusGain" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.FocusGainReloadEnabled_ReloadsOnEachFocusGain" methodname="FocusGainReloadEnabled_ReloadsOnEachFocusGain" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="1515356959" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000019" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1047" name="FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" methodname="FocusLostPauseQuit_TriggersSaveForEachLifecycleEvent" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="2124916567" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000036" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1048" name="PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" methodname="PauseTruePauseFalseQuit_OnlyPauseTrueAndQuitTriggerSave" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="1627860865" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000024" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1049" name="RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" fullname="Tests.Systems.OfflineLifecycleCoordinatorTests.RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" methodname="RapidFocusToggles_RequestsSaveOnlyOnFocusLoss" classname="Tests.Systems.OfflineLifecycleCoordinatorTests" runstate="Runnable" seed="412036941" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000031" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+          </test-suite>
+          <test-suite type="TestFixture" id="1052" name="OfflinePersistenceRegressionTests" fullname="Tests.Systems.OfflinePersistenceRegressionTests" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" testcasecount="3" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.009269" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-suite type="ParameterizedMethod" id="1056" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" testcasecount="3" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.007890" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties />
+              <test-case id="1053" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(120.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(120.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="2085258952" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.002372" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=0, afterOfflineTime=120, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=60.000, applied=60.000, beforeOfflineTime=120, afterOfflineTime=180, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+              <test-case id="1054" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(900.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(900.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="228622443" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.001908" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=900.000, applied=900.000, beforeOfflineTime=0, afterOfflineTime=900, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=450.000, applied=450.000, beforeOfflineTime=900, afterOfflineTime=1350, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+              <test-case id="1055" name="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(3600.0d)" fullname="Tests.Systems.OfflinePersistenceRegressionTests.ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime(3600.0d)" methodname="ReopenCycle_PersistsLatestProgress_AndGrantsOfflineTime" classname="Tests.Systems.OfflinePersistenceRegressionTests" runstate="Runnable" seed="953169221" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.001766" asserts="0">
+                <properties>
+                  <property name="retryIteration" value="0" />
+                  <property name="repeatIteration" value="0" />
+                </properties>
+                <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=3600.000, applied=3600.000, beforeOfflineTime=0, afterOfflineTime=3600, capApplied=false, maxOfflineTime=100000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=1800.000, applied=1800.000, beforeOfflineTime=3600, afterOfflineTime=5400, capApplied=false, maxOfflineTime=100000
+]]></output>
+              </test-case>
+            </test-suite>
+          </test-suite>
+          <test-suite type="TestFixture" id="1057" name="OfflineProgressSystemTests" fullname="Tests.Systems.OfflineProgressSystemTests" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" testcasecount="5" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.006695" total="5" passed="5" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <test-case id="1060" name="ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" methodname="ApplyReturnValues_AwayTimeOverCap_ClampsToMaxOfflineTime" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="788451721" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000276" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=300.000, applied=100.000, beforeOfflineTime=500, afterOfflineTime=600, capApplied=true, maxOfflineTime=600
+]]></output>
+            </test-case>
+            <test-case id="1061" name="ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" methodname="ApplyReturnValues_NegativeAwayTime_MarksCheaterAndClearsOfflineTime" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1377194247" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000242" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=cheater_reset, awayRaw=-5.000, beforeOfflineTime=200, afterOfflineTime=0, maxOfflineTime=0
+]]></output>
+            </test-case>
+            <test-case id="1058" name="ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" methodname="ApplyReturnValues_PositiveAwayTime_AddsToOfflinePool" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="540363869" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000244" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=30, afterOfflineTime=150, capApplied=false, maxOfflineTime=600
+]]></output>
+            </test-case>
+            <test-case id="1062" name="ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" methodname="ApplyReturnValues_TwoValidReopens_AccumulatesAcrossRuns" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1540138797" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000459" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=120.000, applied=120.000, beforeOfflineTime=0, afterOfflineTime=120, capApplied=false, maxOfflineTime=1000
+[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=300.000, applied=300.000, beforeOfflineTime=120, afterOfflineTime=420, capApplied=false, maxOfflineTime=1000
+]]></output>
+            </test-case>
+            <test-case id="1059" name="ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" fullname="Tests.Systems.OfflineProgressSystemTests.ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" methodname="ApplyReturnValues_ZeroAwayTime_DoesNotChangeOfflinePool" classname="Tests.Systems.OfflineProgressSystemTests" runstate="Runnable" seed="1108559248" result="Passed" start-time="2026-02-16 00:18:56Z" end-time="2026-02-16 00:18:56Z" duration="0.000253" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <output><![CDATA[[OfflineTimeDiag] ApplyReturnValues | platform=OSXEditor, result=ok, awayRaw=0.000, applied=0.000, beforeOfflineTime=45, afterOfflineTime=45, capApplied=false, maxOfflineTime=600
+Saving results to: /Users/matthewrushworth/Library/Application Support/BlindsidedGames/Idle Dyson Swarm/TestResults.xml
+]]></output>
+            </test-case>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/Documentation/Test Results/TestResults_20260216_112137dfs.xml
+++ b/Documentation/Test Results/TestResults_20260216_112137dfs.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="2" testcasecount="4" result="Failed(Child)" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0" engine-version="3.5.0.0" clr-version="4.0.30319.42000" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.0721627">
+  <test-suite type="TestSuite" id="1133" name="Idle Dyson Swarm" fullname="Idle Dyson Swarm" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.072163" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+    <properties>
+      <property name="platform" value="EditMode" />
+    </properties>
+    <failure>
+      <message><![CDATA[One or more child tests had errors]]></message>
+    </failure>
+    <test-suite type="Assembly" id="1123" name="Assembly-CSharp-Editor.dll" fullname="/Users/matthewrushworth/Projects/Idle Dyson Swarm/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.066901" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_PID" value="10104" />
+        <property name="_APPDOMAIN" value="Unity Child Domain" />
+        <property name="platform" value="EditMode" />
+        <property name="EditorOnly" value="True" />
+      </properties>
+      <failure>
+        <message><![CDATA[One or more child tests had errors]]></message>
+      </failure>
+      <test-suite type="TestSuite" id="1124" name="Tests" fullname="Tests" runstate="Runnable" testcasecount="106" result="Failed" site="Child" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.066191" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+        <properties />
+        <failure>
+          <message><![CDATA[One or more child tests had errors]]></message>
+        </failure>
+        <test-suite type="TestSuite" id="1128" name="Investigations" fullname="Tests.Investigations" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.065789" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+          <properties />
+          <failure>
+            <message><![CDATA[One or more child tests had errors]]></message>
+          </failure>
+          <test-suite type="TestFixture" id="1118" name="ProductionUiMismatchTests" fullname="Tests.Investigations.ProductionUiMismatchTests" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" testcasecount="4" result="Failed" site="Child" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.065107" total="4" passed="2" failed="2" inconclusive="0" skipped="0" asserts="0">
+            <properties />
+            <failure>
+              <message><![CDATA[One or more child tests had errors]]></message>
+            </failure>
+            <test-case id="1121" name="DataCenters_Control_NoRudimentary_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_Control_NoRudimentary_ParityHolds" methodname="DataCenters_Control_NoRudimentary_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="1980982476" result="Passed" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.051868" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1119" name="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate" methodname="DataCenters_DisplayedRate_Equals_AppliedServerGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="1344988290" result="Failed" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.005778" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[  Displayed data center server rate should match actual server gain per second.
+  Expected: 5.1111111138015985d +/- 1.0000000000000001E-09d
+  But was:  0.11111111380159855d
+]]></message>
+                <stack-trace><![CDATA[at Tests.Investigations.ProductionUiMismatchTests.DataCenters_DisplayedRate_Equals_AppliedServerGainRate () [0x00089] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:53
+]]></stack-trace>
+              </failure>
+            </test-case>
+            <test-case id="1122" name="Planets_Control_NoPocketDimensions_ParityHolds" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_Control_NoPocketDimensions_ParityHolds" methodname="Planets_Control_NoPocketDimensions_ParityHolds" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="601720095" result="Passed" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.000839" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+            </test-case>
+            <test-case id="1120" name="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" fullname="Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" methodname="Planets_DisplayedRate_Equals_AppliedDataCenterGainRate" classname="Tests.Investigations.ProductionUiMismatchTests" runstate="Runnable" seed="900938443" result="Failed" start-time="2026-02-16 00:21:14Z" end-time="2026-02-16 00:21:14Z" duration="0.000401" asserts="0">
+              <properties>
+                <property name="retryIteration" value="0" />
+                <property name="repeatIteration" value="0" />
+              </properties>
+              <failure>
+                <message><![CDATA[  Displayed planet data center rate should match actual data center gain per second.
+  Expected: 2.0277777784503996d +/- 1.0000000000000001E-09d
+  But was:  0.027777778450399637d
+]]></message>
+                <stack-trace><![CDATA[at Tests.Investigations.ProductionUiMismatchTests.Planets_DisplayedRate_Equals_AppliedDataCenterGainRate () [0x00080] in /Users/matthewrushworth/Projects/Idle Dyson Swarm/Assets/Editor/Tests/Investigations/ProductionUiMismatchTests.cs:76
+]]></stack-trace>
+              </failure>
+              <output><![CDATA[Saving results to: /Users/matthewrushworth/Library/Application Support/BlindsidedGames/Idle Dyson Swarm/TestResults.xml
+]]></output>
+            </test-case>
+          </test-suite>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -10,6 +10,7 @@
 - `Assets/Scenes/` game scenes (`Load.unity`, `Game.unity`).
 - `Assets/Scripts/` gameplay code.
   - `Assets/Scripts/Systems/` core gameplay loop, production, UI helpers.
+    - `Assets/Scripts/Systems/Save/` canonical save pipeline, storage adapters, and offline/lifecycle seam abstractions.
   - `Assets/Scripts/Expansion/` Oracle, research, and Dream1 era systems.
   - `Assets/Scripts/Buildings/` building logic and UI managers.
   - `Assets/Scripts/SkillTresStuff/` skill tree logic and UI.


### PR DESCRIPTION
## Summary\n- restore the previously missed lifecycle seam refactor in Oracle persistence flow (IClock/ISaveStore/ILifecycleEvents + coordinator wiring)\n- restore offline regression tests (away-time calculator, lifecycle coordinator, persistence regression, canonical save store)\n- restore production UI mismatch diagnostics and the runtime/UI alignment fix for Data Centers/Planets total rates\n- restore associated docs and structure map updates\n- include the related Unity EditMode XML diagnostics generated during investigation\n\n## Why\n- this change-set was prepared and validated but did not land on main due branch/merge mismatch\n- brings main back in sync with the intended persistence and production-display fixes without touching active skill-tree work\n\n## Testing\n- Not run (Unity/manual in this PR pass)\n- Existing diagnostics included in Documentation/Test Results/*.xml