### PR TITLE
feat(skill-tree): add non-refundable visuals and reason labels

### DIFF
--- a/Assets/Resources/DefaultUITheme.asset
+++ b/Assets/Resources/DefaultUITheme.asset
@@ -23,3 +23,38 @@ MonoBehaviour:
   buttonHighlighted: {r: 0.3, g: 0.3, b: 0.4, a: 1}
   buttonPressed: {r: 0.15, g: 0.15, b: 0.2, a: 1}
   buttonDisabled: {r: 0.15, g: 0.15, b: 0.2, a: 0.5}
+  skillTreeNoRequired:
+    normal: {r: 0.32941177, g: 0.63529414, b: 0.67058825, a: 1}
+    pressed: {r: 0.2576, g: 0.4390621, b: 0.46, a: 1}
+    disabled: {r: 0.21350001, g: 0.33587933, b: 0.35, a: 1}
+    notPurchasableNormal: {r: 0.21350001, g: 0.33587933, b: 0.35, a: 1}
+  skillTreeFragment:
+    normal: {r: 0.67058825, g: 0.32941177, b: 0.49019608, a: 1}
+    pressed: {r: 0.46, g: 0.2576, b: 0.35298392, a: 1}
+    disabled: {r: 0.35, g: 0.21350001, b: 0.2778276, a: 1}
+    notPurchasableNormal: {r: 0.35, g: 0.21350001, b: 0.2778276, a: 1}
+  skillTreeNormal:
+    normal: {r: 0.5019608, g: 0.32941177, b: 0.67058825, a: 1}
+    pressed: {r: 0.35686275, g: 0.25490198, b: 0.45882353, a: 1}
+    disabled: {r: 0.2784314, g: 0.21176471, b: 0.34509805, a: 1}
+    notPurchasableNormal: {r: 0.2784314, g: 0.21176471, b: 0.34509805, a: 1}
+  skillTreeExclusiveLock:
+    normal: {r: 0.4, g: 0.4, b: 0.4, a: 1}
+    pressed: {r: 0.29803923, g: 0.29803923, b: 0.29803923, a: 1}
+    disabled: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+    notPurchasableNormal: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  skillTreeOwned:
+    normal: {r: 0.32941177, g: 0.67058825, b: 0.32941177, a: 1}
+    pressed: {r: 0.239, g: 0.49, b: 0.239, a: 1}
+    disabled: {r: 0.17, g: 0.34, b: 0.17, a: 1}
+    notPurchasableNormal: {r: 0.17, g: 0.34, b: 0.17, a: 1}
+  skillTreeNonRefundable:
+    normal: {r: 0.45, g: 0.18, b: 0.18, a: 1}
+    pressed: {r: 0.35, g: 0.12, b: 0.12, a: 1}
+    disabled: {r: 0.22, g: 0.08, b: 0.08, a: 1}
+    notPurchasableNormal: {r: 0.22, g: 0.08, b: 0.08, a: 1}
+  skillTreeNonRefundableOwned:
+    normal: {r: 0.75, g: 0.2, b: 0.2, a: 1}
+    pressed: {r: 0.55, g: 0.12, b: 0.12, a: 1}
+    disabled: {r: 0.35, g: 0.08, b: 0.08, a: 1}
+    notPurchasableNormal: {r: 0.35, g: 0.08, b: 0.08, a: 1}

--- a/Assets/Scripts/Expansion/Oracle.cs
+++ b/Assets/Scripts/Expansion/Oracle.cs
@@ -51,6 +51,8 @@ using UnityEditor;
  * - Infinity reset boundary ordering must keep offline usage rollover before Infinity data is reinitialized.
  * - Parity formulas in debug helpers must track runtime formula ordering exactly, or false-positive parity deltas appear.
  * - Debug contribution ids/order are used for diagnosis; keep labels stable when adjusting formulas.
+ * - Startup frame cap fallback defaults to 60 FPS when saveSettings.frameRate is unset (0); keep this aligned
+ *   with player-facing FPS controls and defaults if changed.
  * - Changes here do not migrate saves directly but can change interpretation of existing save-state numbers.
  * - Lifecycle callbacks are routed through RuntimeSeams; callback policy changes must stay aligned with
  *   OfflineLifecycleCoordinator tests.
@@ -277,9 +279,9 @@ private void PackSettingsFlags()
             Load();
             Loaded = true;
             Application.targetFrameRate =
-                saveSettings.frameRate != 0
+                saveSettings.frameRate > 0
                     ? saveSettings.frameRate
-                    : Mathf.RoundToInt((float)Screen.currentResolution.refreshRateRatio.value);
+                    : 60;
             bool doubleIpUnlocked = saveSettings.doubleIp || PlayerPrefs.GetInt("doubleip", 0) == 1;
             saveSettings.doubleIp = doubleIpUnlocked;
             if (saveSettings.doubleIp) PlayerPrefs.SetInt("doubleip", 1);

--- a/Assets/Scripts/SkillTreeStuff/LineManager.cs
+++ b/Assets/Scripts/SkillTreeStuff/LineManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GameData;
 using Sirenix.OdinInspector;
@@ -6,6 +7,29 @@ using UnityEngine.UI;
 using UnityEngine.UI.Extensions;
 using static Expansion.Oracle;
 
+/*
+Purpose:
+- Controls one prerequisite connection line in the skill tree and applies the correct visual color based on ownership,
+  availability, queueing, exclusivity, and non-refundable path state.
+
+Where it runs:
+- Runtime on each line renderer instance connecting two skill nodes.
+
+Primary entry points:
+- Unity lifecycle: OnEnable, Start, OnDisable.
+- Refresh callback: SetColor (via skill update events).
+- Geometry setup: SetLine.
+
+Interacts with:
+- Calls into: Oracle (ownership checks, queue checks, prestige/first-run gates), SkillTreeManager (owned + effective
+  non-refundable state), GameDataRegistry/SkillDatabase (fallback skill definition resolution), UILineRenderer.
+- Called by: SkillTreeManager.MakeLines (line construction) and skill update events raised by SkillTreeManager/GameManager.
+
+Change notes:
+- Serialized color fields are configured on the line prefab/scene; changing semantics requires updating authored values.
+- Non-refundable line state now depends on SkillTreeManager.TryGetNotRefundableReasonLabel for each connected owned node.
+- State precedence is intentional: exclusive/disabled/non-refundable must resolve before queued/available/default.
+*/
 public class LineManager : MonoBehaviour
 {
     [SerializeField] private GameManager _gameManager;
@@ -16,6 +40,7 @@ public class LineManager : MonoBehaviour
     [SerializeField] private Color colorDisabled;
     [SerializeField] private Color colorOwned;
     [SerializeField] private Color colorExclusive;
+    [SerializeField] private Color colorNonRefundable = new Color(0.75f, 0.2f, 0.2f, 1f);
     [SerializeField] public RectTransform start;
     [SerializeField] public RectTransform end;
     private UILineRenderer lr;
@@ -58,6 +83,8 @@ public class LineManager : MonoBehaviour
         SkillDefinition endDefinition = ResolveEndDefinition();
         bool startOwned = ResolveOwned(startSkillManager, startSkillId, startSkillKey);
         bool endOwned = ResolveOwned(endSkillManager, endSkillId, endSkillKey);
+        bool endNotRefundable = ResolveEffectivelyNotRefundable(endSkillManager, endSkillId, endSkillKey, endOwned);
+        bool nonRefundablePath = startOwned && endOwned && endNotRefundable;
         bool missingRequirement = false;
         if (endDefinition != null && endDefinition.requiredSkillIds != null &&
             endDefinition.requiredSkillIds.Length >= 1)
@@ -92,6 +119,12 @@ public class LineManager : MonoBehaviour
             return;
         }
 
+        if (nonRefundablePath)
+        {
+            lr.color = colorNonRefundable;
+            return;
+        }
+
         bool queued = false;
         string resolvedEndId = ResolveEndSkillId();
         queued = oracle.IsAutoAssignmentQueued(endSkillKey, resolvedEndId);
@@ -106,6 +139,47 @@ public class LineManager : MonoBehaviour
             lr.color = colorMissing;
         else
             lr.color = colorDefault;
+    }
+
+    private bool ResolveEffectivelyNotRefundable(SkillTreeManager manager, string id, int key, bool owned)
+    {
+        if (!owned) return false;
+
+        SkillTreeManager resolvedManager = ResolveManager(manager, id, key);
+        if (resolvedManager != null)
+        {
+            return resolvedManager.TryGetNotRefundableReasonLabel(out _);
+        }
+
+        string resolvedId = ResolveSkillId(id, key);
+        if (string.IsNullOrEmpty(resolvedId)) return false;
+        GameDataRegistry registry = GameDataRegistry.Instance;
+        if (registry == null || registry.skillDatabase == null) return false;
+        if (!registry.skillDatabase.TryGet(resolvedId, out SkillDefinition definition) || definition == null) return false;
+        return !definition.refundable;
+    }
+
+    private SkillTreeManager ResolveManager(SkillTreeManager manager, string id, int key)
+    {
+        if (manager != null) return manager;
+        string resolvedId = ResolveSkillId(id, key);
+        if (string.IsNullOrEmpty(resolvedId) || oracle == null || oracle.allSkillTreeManagers == null) return null;
+
+        foreach (SkillTreeManager candidate in oracle.allSkillTreeManagers)
+        {
+            if (candidate == null) continue;
+            if (!string.Equals(candidate.SkillId, resolvedId, StringComparison.Ordinal)) continue;
+            return candidate;
+        }
+
+        return null;
+    }
+
+    private static string ResolveSkillId(string id, int key)
+    {
+        if (!string.IsNullOrEmpty(id)) return id;
+        if (SkillIdMap.TryGetId(key, out string mappedId)) return mappedId;
+        return null;
     }
 
     private bool ResolveOwned(SkillTreeManager manager, string id, int key)
@@ -163,4 +237,3 @@ public class LineManager : MonoBehaviour
         lr.Points = pointlist.ToArray();
     }
 }
-

--- a/Assets/Scripts/SkillTreeStuff/SkillTreeConfirmationManager.cs
+++ b/Assets/Scripts/SkillTreeStuff/SkillTreeConfirmationManager.cs
@@ -7,6 +7,31 @@ using UnityEngine;
 using UnityEngine.UI;
 using static Expansion.Oracle;
 
+/*
+Purpose:
+- Controls the skill confirmation popup: title/description/cost text, assign/unassign button states, auto-assign
+  actions, and not-refundable warning messaging.
+
+Where it runs:
+- Runtime on the skill tree confirmation panel object.
+
+Primary entry points:
+- Unity lifecycle: Start.
+- Popup flow: SetPosition, SetTexts, CloseConfirm.
+- Button callbacks: RemoveSkillFromAutoAssign, AddSkillToAutoAssign.
+
+Interacts with:
+- Calls into: SkillTreeManager (selection context, purchase call, not-refundable reason labels), Oracle save APIs
+  (auto-assign list reads/writes), GameDataRegistry/SkillDatabase (fallback skill lookup).
+- Called by: SkillTreeManager.ShowConfirmation and Unity UI button events.
+
+Change notes:
+- Serialized fields map to prefab references in Panel.prefab; renames/type changes require prefab rewiring.
+- Not-refundable warning copy now comes from SkillTreeManager.TryGetNotRefundableReasonLabel; changing that method
+  changes popup text and warning visibility behavior.
+- Color arrays (normalColours, fragmentColours, nonRefundableColours) are popup-local presentation data and are
+  independent of the skill-node button colors sourced from UITheme.
+*/
 public class SkillTreeConfirmationManager : MonoBehaviour
 {
     [SerializeField] private GameManager _gameManager;
@@ -17,6 +42,7 @@ public class SkillTreeConfirmationManager : MonoBehaviour
     [SerializeField] private Button autoAssignRemovalButton;
     [SerializeField] private Button autoAssignAddButton;
     [SerializeField] private GameObject notRefundableMessage;
+    [SerializeField] private TMP_Text notRefundableMessageText;
     public TMP_Text confirmButtonText;
 
     [SerializeField] private TMP_Text nameText;
@@ -96,11 +122,23 @@ public class SkillTreeConfirmationManager : MonoBehaviour
             }
         }
 
-        bool refundable = definition == null || definition.refundable;
+        string notRefundableLabel = string.Empty;
+        bool isNotRefundable = false;
+        if (skillTreeManager != null)
+        {
+            isNotRefundable = skillTreeManager.TryGetNotRefundableReasonLabel(out notRefundableLabel);
+        }
         bool isFragment = definition != null && definition.isFragment;
+        bool isDirectIntrinsicNonRefundable = definition != null && !definition.refundable;
         bool owned = skillTreeManager.IsOwned;
 
-        notRefundableMessage.SetActive(!refundable);
+        notRefundableMessage.SetActive(isNotRefundable);
+        TMP_Text notRefundableText = ResolveNotRefundableMessageText();
+        if (notRefundableText != null)
+        {
+            notRefundableText.text = isNotRefundable ? notRefundableLabel : "Not Refundable";
+        }
+
         string skillId = skillTreeManager.SkillId;
         if (string.IsNullOrEmpty(skillId)) SkillIdMap.TryGetId(skillTreeManager.skillKey, out skillId);
         List<string> autoAssignIds = oracle.GetAutoAssignmentSkillIds();
@@ -110,7 +148,7 @@ public class SkillTreeConfirmationManager : MonoBehaviour
         nameText.text = name;
         descText.text = description;
         technicalDescText.text = technicalDescription;
-        if (isFragment && refundable)
+        if (isFragment && !isNotRefundable)
         {
             string fragmentPlusOrMinus = owned ? "-1" : "+1";
             cost +=
@@ -121,7 +159,7 @@ public class SkillTreeConfirmationManager : MonoBehaviour
 
         if (definition != null && definition.exclusiveWithIds != null)
         {
-            if (definition.exclusiveWithIds.Length >= 1 && !refundable)
+            if (definition.exclusiveWithIds.Length >= 1 && isDirectIntrinsicNonRefundable)
             {
                 bool makeComma = true;
 
@@ -141,13 +179,13 @@ public class SkillTreeConfirmationManager : MonoBehaviour
             }
         }
 
-        if (isFragment)
+        if (isFragment && !isNotRefundable)
         {
             foreach (Image image in highlights) image.color = fragmentColours[0];
             background.color = fragmentColours[1];
             background.OutlineColor = fragmentColours[0];
         }
-        else if (!refundable)
+        else if (isNotRefundable)
         {
             foreach (Image image in highlights) image.color = nonRefundableColours[0];
             background.color = nonRefundableColours[1];
@@ -161,6 +199,14 @@ public class SkillTreeConfirmationManager : MonoBehaviour
         }
 
         costText.text = cost;
+    }
+
+    private TMP_Text ResolveNotRefundableMessageText()
+    {
+        if (notRefundableMessageText != null) return notRefundableMessageText;
+        if (notRefundableMessage == null) return null;
+        notRefundableMessageText = notRefundableMessage.GetComponent<TMP_Text>();
+        return notRefundableMessageText;
     }
 
     private string ResolveSkillName(string id)
@@ -177,4 +223,3 @@ public class SkillTreeConfirmationManager : MonoBehaviour
         return id;
     }
 }
-

--- a/Assets/Scripts/SkillTreeStuff/SkillTreeManager.cs
+++ b/Assets/Scripts/SkillTreeStuff/SkillTreeManager.cs
@@ -23,13 +23,14 @@ Primary entry points:
 - UI input: Clicked, RightClicked, OnPointerClick.
 - Refresh path: UpdateSkill (from local and global update events).
 - Mutations: PurchaseSkill, ResetSkills.
+- Confirmation read API: TryGetNotRefundableReasonLabel.
 
 Interacts with:
 - Calls into: Expansion.Oracle (save data, ownership reads/writes, events, auto-assign APIs), GameDataRegistry/
   SkillDatabase/SkillDefinition (skill metadata), SkillTreeConfirmationManager (description/confirm modal),
   UIThemeProvider/UITheme (color sets), GameManager and DebugOptions update events.
 - Called by: Unity UI Button events, Unity lifecycle, Oracle/GameManager/DebugOptions skill update events,
-  and other systems that invoke SkillTreeManager.UpdateSkills.
+  SkillTreeConfirmationManager (reason label queries), and other systems that invoke SkillTreeManager.UpdateSkills.
 
 Change notes:
 - Serialized references (skillButton, purchasedImage, texts, ids/keys) are scene/prefab wired; renames require
@@ -38,6 +39,10 @@ Change notes:
   without the others can allow visual state and purchase rules to diverge.
 - skillKey/SkillId/SkillDefinition mapping relies on SkillIdMap + SkillDatabase + Oracle skill flags; ID changes
   must be coordinated with save data migration and any ScriptableObject ID updates.
+- Effective non-refundable visuals and labels are computed from direct refundable flags, dynamic unrefundable locks,
+  and transitive required-skill ancestry of assigned direct non-refundable skills; changing that contract affects both
+  node coloring and confirmation warnings. Owned refundable/non-refundable skills use dedicated button color sets and
+  the purchased overlay is kept hidden.
 */
 [SelectionBase]
 public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
@@ -62,9 +67,22 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
     {
         NoRequired,
         Fragment,
+        Owned,
+        NonRefundable,
+        NonRefundableOwned,
         Normal,
         ExclusiveLock
     }
+
+    private enum NotRefundableReasonType
+    {
+        None,
+        DirectIntrinsic,
+        DirectDynamicLock,
+        RequiredByDirectNonRefundableSkill
+    }
+
+    private const string NotRefundableWithRequiredSkillsLabel = "Not Refundable (Including Required Skills)";
 
     private static readonly UITheme.SkillTreeButtonColors FallbackNoRequiredColors = new UITheme.SkillTreeButtonColors
     {
@@ -89,6 +107,31 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
         disabled = new Color(0.2784314f, 0.21176471f, 0.34509805f),
         notPurchasableNormal = new Color(0.2784314f, 0.21176471f, 0.34509805f)
     };
+
+    private static readonly UITheme.SkillTreeButtonColors FallbackOwnedColors = new UITheme.SkillTreeButtonColors
+    {
+        normal = new Color(0.32941177f, 0.67058825f, 0.32941177f),
+        pressed = new Color(0.239f, 0.49f, 0.239f),
+        disabled = new Color(0.17f, 0.34f, 0.17f),
+        notPurchasableNormal = new Color(0.17f, 0.34f, 0.17f)
+    };
+
+    private static readonly UITheme.SkillTreeButtonColors FallbackNonRefundableColors = new UITheme.SkillTreeButtonColors
+    {
+        normal = new Color(0.45f, 0.18f, 0.18f),
+        pressed = new Color(0.35f, 0.12f, 0.12f),
+        disabled = new Color(0.22f, 0.08f, 0.08f),
+        notPurchasableNormal = new Color(0.22f, 0.08f, 0.08f)
+    };
+
+    private static readonly UITheme.SkillTreeButtonColors FallbackNonRefundableOwnedColors =
+        new UITheme.SkillTreeButtonColors
+        {
+            normal = new Color(0.75f, 0.2f, 0.2f),
+            pressed = new Color(0.55f, 0.12f, 0.12f),
+            disabled = new Color(0.35f, 0.08f, 0.08f),
+            notPurchasableNormal = new Color(0.35f, 0.08f, 0.08f)
+        };
 
     private static readonly UITheme.SkillTreeButtonColors FallbackExclusiveLockColors = new UITheme.SkillTreeButtonColors
     {
@@ -203,6 +246,25 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
     public SkillDefinition Definition => ResolveSkillDefinition();
 
     public bool IsOwned => IsOwnedInternal();
+
+    public bool TryGetNotRefundableReasonLabel(out string label)
+    {
+        if (!TryResolveNotRefundableReason(out NotRefundableReasonType reasonType, out string reasonSkillId))
+        {
+            label = null;
+            return false;
+        }
+
+        label = reasonType switch
+        {
+            NotRefundableReasonType.DirectIntrinsic => NotRefundableWithRequiredSkillsLabel,
+            NotRefundableReasonType.DirectDynamicLock => $"Not Refundable (Due to: {ResolveSkillName(reasonSkillId)})",
+            NotRefundableReasonType.RequiredByDirectNonRefundableSkill =>
+                $"Not Refundable (Required by: {ResolveSkillName(reasonSkillId)})",
+            _ => NotRefundableWithRequiredSkillsLabel
+        };
+        return true;
+    }
 
     private SkillDefinition ResolveSkillDefinition()
     {
@@ -325,6 +387,162 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
         }
 
         return refundable;
+    }
+
+    private bool IsEffectivelyNotRefundable()
+    {
+        return TryResolveNotRefundableReason(out _, out _);
+    }
+
+    private bool TryResolveNotRefundableReason(out NotRefundableReasonType reasonType, out string reasonSkillId)
+    {
+        reasonType = NotRefundableReasonType.None;
+        reasonSkillId = null;
+
+        SkillDefinition definition = ResolveSkillDefinition();
+        if (definition == null) return false;
+
+        if (!definition.refundable)
+        {
+            reasonType = NotRefundableReasonType.DirectIntrinsic;
+            return true;
+        }
+
+        if (TryGetDynamicLockingSkillId(definition, out string lockingSkillId))
+        {
+            reasonType = NotRefundableReasonType.DirectDynamicLock;
+            reasonSkillId = lockingSkillId;
+            return true;
+        }
+
+        string currentSkillId = ResolveSkillId();
+        if (TryGetRequiringDirectNonRefundableSkillId(currentSkillId, out string requiringSkillId))
+        {
+            reasonType = NotRefundableReasonType.RequiredByDirectNonRefundableSkill;
+            reasonSkillId = requiringSkillId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetDynamicLockingSkillId(SkillDefinition definition, out string lockingSkillId)
+    {
+        lockingSkillId = null;
+        if (definition == null || definition.unrefundableWithIds == null || definition.unrefundableWithIds.Length == 0)
+            return false;
+        if (!IsOwnedInternal()) return false;
+
+        foreach (string otherId in definition.unrefundableWithIds)
+        {
+            if (string.IsNullOrEmpty(otherId)) continue;
+            if (!oracle.IsSkillOwned(otherId)) continue;
+            lockingSkillId = otherId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetRequiringDirectNonRefundableSkillId(string currentSkillId, out string requiringSkillId)
+    {
+        requiringSkillId = null;
+        if (string.IsNullOrEmpty(currentSkillId)) return false;
+        if (!IsOwnedInternal()) return false;
+
+        GameDataRegistry registry = GameDataRegistry.Instance;
+        SkillDatabase database = registry != null ? registry.skillDatabase : null;
+        if (database != null && database.skills != null && database.skills.Count > 0)
+        {
+            foreach (SkillDefinition candidate in database.skills)
+            {
+                if (candidate == null || string.IsNullOrEmpty(candidate.id)) continue;
+                if (candidate.refundable) continue;
+                if (!oracle.IsSkillOwned(candidate.id)) continue;
+                if (candidate.id == currentSkillId) continue;
+                if (!IsInRequiredChain(candidate.id, currentSkillId, database)) continue;
+
+                requiringSkillId = candidate.id;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (oracle == null || oracle.allSkillTreeManagers == null) return false;
+        foreach (SkillTreeManager manager in oracle.allSkillTreeManagers)
+        {
+            if (manager == null || manager == this) continue;
+            string candidateSkillId = manager.SkillId;
+            if (string.IsNullOrEmpty(candidateSkillId) || candidateSkillId == currentSkillId) continue;
+            if (!manager.IsOwned) continue;
+            SkillDefinition candidateDefinition = manager.Definition;
+            if (candidateDefinition == null || candidateDefinition.refundable) continue;
+            if (!IsInRequiredChain(candidateSkillId, currentSkillId, null)) continue;
+
+            requiringSkillId = candidateSkillId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsInRequiredChain(string rootSkillId, string targetSkillId, SkillDatabase database)
+    {
+        if (string.IsNullOrEmpty(rootSkillId) || string.IsNullOrEmpty(targetSkillId)) return false;
+        HashSet<string> visited = new HashSet<string>(StringComparer.Ordinal) { rootSkillId };
+        Queue<string> toVisit = new Queue<string>();
+        toVisit.Enqueue(rootSkillId);
+
+        while (toVisit.Count > 0)
+        {
+            string current = toVisit.Dequeue();
+            string[] requiredIds = GetRequiredIdsBySkillId(current, database);
+            if (requiredIds == null || requiredIds.Length == 0) continue;
+
+            foreach (string requiredId in requiredIds)
+            {
+                if (string.IsNullOrEmpty(requiredId)) continue;
+                if (requiredId == targetSkillId) return true;
+                if (!visited.Add(requiredId)) continue;
+                toVisit.Enqueue(requiredId);
+            }
+        }
+
+        return false;
+    }
+
+    private string[] GetRequiredIdsBySkillId(string id, SkillDatabase database)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+        if (database != null && database.TryGet(id, out SkillDefinition definition))
+        {
+            return definition.requiredSkillIds;
+        }
+
+        if (oracle == null || oracle.allSkillTreeManagers == null) return null;
+        foreach (SkillTreeManager manager in oracle.allSkillTreeManagers)
+        {
+            if (manager == null) continue;
+            if (!string.Equals(manager.SkillId, id, StringComparison.Ordinal)) continue;
+            return manager.GetRequiredSkillIds();
+        }
+
+        return null;
+    }
+
+    private string ResolveSkillName(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return string.Empty;
+        GameDataRegistry registry = GameDataRegistry.Instance;
+        if (registry != null && registry.skillDatabase != null &&
+            registry.skillDatabase.TryGet(id, out SkillDefinition definition) &&
+            !string.IsNullOrEmpty(definition.displayName))
+        {
+            return definition.displayName;
+        }
+
+        return id;
     }
 
     private List<string> GetOwnedDependentSkillIdsRecursive(string rootId)
@@ -562,7 +780,7 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
     private void UpdateSkill()
     {
         EnableSKills();
-        purchasedImage.SetActive(false);
+        if (purchasedImage != null) purchasedImage.SetActive(false);
         if (ResolveSkillDefinition() == null)
         {
             skillButton.interactable = false;
@@ -580,7 +798,8 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
                               && AreRequirementsMet(shadowIds)
                               && skillTreeData.skillPointsTree >= cost
                               && !exclusiveOwned;
-        SkillTreeColorType colorType = ResolveCurrentColorType(exclusiveOwned);
+        bool isEffectivelyNotRefundable = IsEffectivelyNotRefundable();
+        SkillTreeColorType colorType = ResolveCurrentColorType(exclusiveOwned, isEffectivelyNotRefundable, owned);
         bool useNotPurchasableVisual = !oracle.saveSettings.skillsBuyOnTap && !owned && !canPurchaseNow;
 
         if (oracle.saveSettings.skillsBuyOnTap)
@@ -588,7 +807,6 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
             if (owned)
             {
                 available = false;
-                purchasedImage.SetActive(true);
             }
             else
             {
@@ -598,19 +816,18 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
             }
             if (exclusiveOwned) available = false;
         }
-        else
-        {
-            if (owned) purchasedImage.SetActive(true);
-        }
 
         ApplySkillButtonColors(colorType, useNotPurchasableVisual);
         skillButton.interactable = oracle.saveSettings.skillsBuyOnTap ? available : true;
         ApplySkills?.Invoke();
     }
 
-    private SkillTreeColorType ResolveCurrentColorType(bool exclusiveOwned)
+    private SkillTreeColorType ResolveCurrentColorType(bool exclusiveOwned, bool isEffectivelyNotRefundable, bool owned)
     {
         if (exclusiveOwned) return SkillTreeColorType.ExclusiveLock;
+        if (isEffectivelyNotRefundable && owned) return SkillTreeColorType.NonRefundableOwned;
+        if (isEffectivelyNotRefundable) return SkillTreeColorType.NonRefundable;
+        if (owned) return SkillTreeColorType.Owned;
         if (GetIsFragment()) return SkillTreeColorType.Fragment;
         string[] requiredIds = GetRequiredSkillIds();
         if (requiredIds == null || requiredIds.Length == 0) return SkillTreeColorType.NoRequired;
@@ -647,27 +864,16 @@ public class SkillTreeManager : MonoBehaviour, IPointerClickHandler
     private UITheme.SkillTreeButtonColors ResolveSkillTreeColors(SkillTreeColorType colorType)
     {
         UITheme theme = UIThemeProvider.ActiveTheme;
-        if (theme != null
-            && theme.skillTreeNoRequired != null
-            && theme.skillTreeFragment != null
-            && theme.skillTreeNormal != null
-            && theme.skillTreeExclusiveLock != null)
-        {
-            return colorType switch
-            {
-                SkillTreeColorType.NoRequired => theme.skillTreeNoRequired,
-                SkillTreeColorType.Fragment => theme.skillTreeFragment,
-                SkillTreeColorType.ExclusiveLock => theme.skillTreeExclusiveLock,
-                _ => theme.skillTreeNormal
-            };
-        }
-
         return colorType switch
         {
-            SkillTreeColorType.NoRequired => FallbackNoRequiredColors,
-            SkillTreeColorType.Fragment => FallbackFragmentColors,
-            SkillTreeColorType.ExclusiveLock => FallbackExclusiveLockColors,
-            _ => FallbackNormalColors
+            SkillTreeColorType.NoRequired => theme?.skillTreeNoRequired ?? FallbackNoRequiredColors,
+            SkillTreeColorType.Fragment => theme?.skillTreeFragment ?? FallbackFragmentColors,
+            SkillTreeColorType.Owned => theme?.skillTreeOwned ?? FallbackOwnedColors,
+            SkillTreeColorType.NonRefundable => theme?.skillTreeNonRefundable ?? FallbackNonRefundableColors,
+            SkillTreeColorType.NonRefundableOwned =>
+                theme?.skillTreeNonRefundableOwned ?? FallbackNonRefundableOwnedColors,
+            SkillTreeColorType.ExclusiveLock => theme?.skillTreeExclusiveLock ?? FallbackExclusiveLockColors,
+            _ => theme?.skillTreeNormal ?? FallbackNormalColors
         };
     }
 

--- a/Assets/Scripts/Systems/GameManager.cs
+++ b/Assets/Scripts/Systems/GameManager.cs
@@ -37,6 +37,8 @@ using static Expansion.Oracle;
 ///   in short time form.
 /// - Timer value strings should pass <c>colourOverride</c> into <see cref="CalcUtils.FormatTime"/> rather than wrapping
 ///   the full output in a color tag, so unit suffixes remain uncolored.
+/// - Infinity section <c>Run Time</c> rows (`Current`/`Previous`) intentionally pass <c>showDecimal: true</c>
+///   to preserve sub-second precision in the side-panel stats block.
 /// - Stats ordering/section headers in <c>skillTimersDisplayText</c> are a UX contract:
 ///   bold General metrics, then bold Infinity section, then bold Skills section.
 /// - General metrics, s/IP, and Run/Offline Current/Previous rows use the same small text scale as skill detail lines.
@@ -898,9 +900,9 @@ public class GameManager : MonoBehaviour
             $"<br>{smallTextStart}s/IP: {CalcUtils.FormatTime(secondsPerIp, showDecimal: true, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}";
         skillTimersDisplayText += $"{halfHeightBreak}{smallTextStart}<b>Run Time</b>";
         skillTimersDisplayText +=
-            $"<br>Current: {CalcUtils.FormatTime(CurrentRunTime(), shortForm: true, mspace: false, colourOverride: scienceColor)}";
+            $"<br>Current: {CalcUtils.FormatTime(CurrentRunTime(), showDecimal: true, shortForm: true, mspace: false, colourOverride: scienceColor)}";
         skillTimersDisplayText +=
-            $"<br>Previous: {CalcUtils.FormatTime(oracle.saveSettings.timeLastInfinity, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}";
+            $"<br>Previous: {CalcUtils.FormatTime(oracle.saveSettings.timeLastInfinity, showDecimal: true, shortForm: true, mspace: false, colourOverride: scienceColor)}{smallTextEnd}";
 
         skillTimersDisplayText += $"{halfHeightBreak}{smallTextStart}<b>Offline Time Used</b>";
         skillTimersDisplayText +=

--- a/Assets/Scripts/UI/Theme/UITheme.cs
+++ b/Assets/Scripts/UI/Theme/UITheme.cs
@@ -23,7 +23,8 @@ namespace IdleDysonSwarm.UI
     Change notes:
     - Serialized field names are asset schema; renames require migration of existing UITheme assets.
     - SkillTreeButtonColors additions/changes must remain compatible with existing theme assets loaded from
-      Resources/DefaultUITheme.asset.
+      Resources/DefaultUITheme.asset; newly added groups (for example owned and non-refundable variants) must have
+      safe defaults.
     - If defaults change here, verify both fallback behavior and any authored UITheme assets so visuals remain
       intentional.
     */
@@ -123,6 +124,30 @@ namespace IdleDysonSwarm.UI
             pressed = new Color(0.29803923f, 0.29803923f, 0.29803923f),
             disabled = new Color(0.2f, 0.2f, 0.2f),
             notPurchasableNormal = new Color(0.2f, 0.2f, 0.2f)
+        };
+
+        public SkillTreeButtonColors skillTreeOwned = new SkillTreeButtonColors
+        {
+            normal = new Color(0.32941177f, 0.67058825f, 0.32941177f),
+            pressed = new Color(0.239f, 0.49f, 0.239f),
+            disabled = new Color(0.17f, 0.34f, 0.17f),
+            notPurchasableNormal = new Color(0.17f, 0.34f, 0.17f)
+        };
+
+        public SkillTreeButtonColors skillTreeNonRefundable = new SkillTreeButtonColors
+        {
+            normal = new Color(0.45f, 0.18f, 0.18f),
+            pressed = new Color(0.35f, 0.12f, 0.12f),
+            disabled = new Color(0.22f, 0.08f, 0.08f),
+            notPurchasableNormal = new Color(0.22f, 0.08f, 0.08f)
+        };
+
+        public SkillTreeButtonColors skillTreeNonRefundableOwned = new SkillTreeButtonColors
+        {
+            normal = new Color(0.75f, 0.2f, 0.2f),
+            pressed = new Color(0.55f, 0.12f, 0.12f),
+            disabled = new Color(0.35f, 0.08f, 0.08f),
+            notPurchasableNormal = new Color(0.35f, 0.08f, 0.08f)
         };
 
         // Cached rich text color tags for performance

--- a/Documentation/Code/GameManager.md
+++ b/Documentation/Code/GameManager.md
@@ -41,6 +41,7 @@
     are rendered at small text size (`<size=80%>`).
   - Skill rows are rendered at small text size with bold skill names.
   - `s/IP` is rendered with `showDecimal: true` to preserve sub-second precision.
+  - `Run Time` (`Current`/`Previous`) rows are also rendered with `showDecimal: true` for sub-second precision.
 
 ## Save / Load Implications
 - Mutates values in save-backed structures through `Oracle` references, so runtime changes persist into future saves.
@@ -61,5 +62,6 @@
    - total bots
 3. Verify values still increment correctly over time and no TMP rich-text warnings/errors appear in console.
 4. Spend offline time and confirm the blue side-panel run-info block updates:
+   - `Run Time` `Current`/`Previous` values show decimal seconds when sub-second precision exists.
    - `Offline Time Used (This Infinity)` increases by spent seconds.
    - `Offline Time Used (Previous Infinity)` remains unchanged until the next Infinity reset.

--- a/Documentation/Code/LineManager.md
+++ b/Documentation/Code/LineManager.md
@@ -1,0 +1,43 @@
+# LineManager
+
+## Purpose and contract
+`LineManager` controls one rendered connection between two skill nodes in the skill tree.
+
+It owns:
+- line geometry setup (`SetLine`),
+- line color state resolution (`SetColor`) based on skill ownership and gating.
+
+It delegates:
+- effective refundability reasoning to `SkillTreeManager.TryGetNotRefundableReasonLabel`,
+- ownership/queue/save truth to `Oracle` + `SkillTreeManager`.
+
+## Color-state precedence
+`SetColor()` resolves in this order:
+1. `colorExclusive` when end skill is blocked by an owned exclusive.
+2. `colorDisabled` when the line's end skill is hidden by prestige/first-run gates.
+3. `colorNonRefundable` when both connected skills are owned and the destination/end skill is effectively not refundable.
+4. `colorOwned` when both connected skills are owned.
+5. `colorQueued` when end skill is queued for auto-assignment.
+6. `colorAvailable` when start is owned.
+7. `colorMissing` when requirement state indicates missing path.
+8. `colorDefault` fallback.
+
+## Data flow
+1. `SkillTreeManager.MakeLines()` instantiates and wires each line with start/end managers, IDs, keys, and rects.
+2. `LineManager.Start()` caches `UILineRenderer`, computes points, and applies initial color.
+3. `LineManager` subscribes to skill update events and re-runs `SetColor()` on updates.
+
+## Save/load implications
+- No direct save schema changes.
+- Reads dynamic state from Oracle ownership and auto-assignment queues.
+
+## Performance notes
+- `SetColor()` runs frequently across many lines; manager resolution is ID-based and short-circuits on direct references.
+- Non-refundable path checks prefer linked `SkillTreeManager` references to avoid extra database traversal.
+
+## Quick verification
+1. Assign a normal refundable chain; owned lines should remain owned color (not red).
+2. Assign an intrinsic non-refundable skill with owned prerequisites; connecting owned lines should turn red.
+3. Unassign the non-refundable skill; prerequisite path lines should revert from red.
+4. Trigger an exclusive lock and verify exclusive color still overrides red.
+5. Verify a line from a non-refundable prerequisite into a refundable owned skill remains green (owned), not red.

--- a/Documentation/Code/SkillTreeConfirmationManager.md
+++ b/Documentation/Code/SkillTreeConfirmationManager.md
@@ -1,0 +1,45 @@
+# SkillTreeConfirmationManager
+
+## Purpose and contract
+`SkillTreeConfirmationManager` owns the skill confirmation popup shown from skill nodes. It is responsible for:
+- opening/closing and positioning the popup,
+- rendering skill text (name, description, technical description, cost),
+- driving assign/unassign actions through the selected `SkillTreeManager`,
+- toggling auto-assign add/remove actions,
+- rendering not-refundable warning visibility and reason copy.
+
+The popup must stay consistent with `SkillTreeManager` rules for refundability and reason labeling.
+
+## Data flow
+1. `SkillTreeManager.ShowConfirmation()` assigns `skillTreeManager`, then calls `SetTexts()`/`SetPosition()`.
+2. `SetTexts()`:
+- resolves the active `SkillDefinition`,
+- asks `skillTreeManager.TryGetNotRefundableReasonLabel(out label)` for warning state and copy,
+- updates message visibility/copy and popup colors (normal/fragment/non-refundable),
+- updates auto-assign button visibility from Oracle auto-assignment IDs.
+3. Confirm button calls `skillTreeManager.PurchaseSkill()` to execute assign/unassign mutation.
+
+## Not-refundable message behavior
+- Message is hidden when `TryGetNotRefundableReasonLabel` returns false.
+- Message is shown with exact label returned from `SkillTreeManager` when true.
+- Message text supports:
+  - `Not Refundable (Including Required Skills)`
+  - `Not Refundable (Due to: <Skill Name>)`
+  - `Not Refundable (Required by: <Skill Name>)`
+
+## Save/load implications
+- No direct save schema changes are owned here.
+- Writes occur only through Oracle auto-assign list updates and `PurchaseSkill()` delegation.
+
+## Performance notes
+- `SetTexts()` executes on popup open, not per-frame; database lookups and label resolution are acceptable.
+- Keep reason-resolution logic in `SkillTreeManager` so confirmation UI remains presentation-focused.
+
+## Quick verification
+1. Open popup for an intrinsic non-refundable skill and verify warning label is visible with:
+- `Not Refundable (Including Required Skills)`.
+2. Open popup for an assigned prerequisite inherited from a non-refundable descendant and verify:
+- warning shows `Not Refundable (Required by: <Skill Name>)`.
+3. If a dynamic lock (`unrefundableWithIds`) applies, verify warning shows:
+- `Not Refundable (Due to: <Skill Name>)`.
+4. Open popup for a refundable skill and verify warning is hidden.

--- a/Documentation/Code/SkillTreeManager.md
+++ b/Documentation/Code/SkillTreeManager.md
@@ -5,7 +5,8 @@
 - rendering the node's current state (owned, available, line visibility/color, and theme colors),
 - handling click/right-click behavior (direct buy/unassign vs confirmation flow),
 - enforcing purchase and unassign rules before mutating save state,
-- coordinating with auto-assign lists/presets when skills are removed.
+- coordinating with auto-assign lists/presets when skills are removed,
+- exposing effective not-refundable reason labels consumed by confirmation UI.
 
 The node's visual state must always match the purchase constraints enforced by `ShowConfirmation` and `PurchaseSkill`.
 
@@ -18,6 +19,22 @@ The node's visual state must always match the purchase constraints enforced by `
 - `PurchaseSkill()` updates Oracle-owned flags, skill points, fragments, and auto-assign/preset queues.
 - `UpdateSkills` event is raised to fan out UI refresh across all nodes/consumers.
 
+## Effective not-refundable rules
+`SkillTreeManager` treats a node as effectively not refundable when any of these are true:
+1. Direct intrinsic non-refundable: `SkillDefinition.refundable == false`.
+2. Direct dynamic lock: this owned skill has an owned entry in `unrefundableWithIds`.
+3. Inherited prerequisite lock: this owned skill appears in the transitive `requiredSkillIds` ancestry of an owned
+   direct intrinsic non-refundable skill.
+
+Transitive ancestry follows the full root path through `requiredSkillIds` only (not `shadowRequirementIds`).
+
+Confirmation label API:
+- `TryGetNotRefundableReasonLabel(out string label)` returns false when refundable.
+- Returned labels:
+  - `Not Refundable (Including Required Skills)` for direct intrinsic non-refundable skills.
+  - `Not Refundable (Due to: <Skill Name>)` for dynamic lock cases.
+  - `Not Refundable (Required by: <Skill Name>)` for inherited prerequisite-lock cases.
+
 ## Save/load implications
 - Skill ownership is stored in Oracle/skill-tree save flags keyed by skill IDs.
 - Costs/fragments are read from `SkillDefinition` and applied to `skillPointsTree` / `fragments`.
@@ -28,6 +45,20 @@ The node's visual state must always match the purchase constraints enforced by `
 - Tap-to-buy mode: non-purchasable skills become non-interactable.
 - Description mode: nodes remain clickable; non-purchasable and unowned nodes use `notPurchasableNormal` from the current skill-tree color category.
 - If a theme asset does not define `notPurchasableNormal`, code falls back to a dimmed `normal` color.
+- Color precedence:
+  1. Exclusive lock
+  2. Non-refundable (owned)
+  3. Non-refundable (unowned)
+  4. Owned (refundable)
+  5. Fragment
+  6. No-required
+  7. Normal
+- Non-refundable node colors come from:
+  - `UITheme.skillTreeNonRefundableOwned` for assigned non-refundable nodes (full red),
+  - `UITheme.skillTreeNonRefundable` for unassigned non-refundable nodes (greyed red),
+  with hardcoded fallback safety only.
+- Owned refundable node colors come from `UITheme.skillTreeOwned` (with fallback safety only).
+- Purchased overlay visuals are intentionally suppressed; owned state is communicated by button colors.
 
 ## Performance notes
 - `UpdateSkill()` runs frequently via several update events; avoid expensive allocations or broad graph traversals in this path.
@@ -39,8 +70,18 @@ The node's visual state must always match the purchase constraints enforced by `
 - Unowned + purchasable node uses normal color and opens confirmation popup.
 - Unowned + not purchasable node uses dim/not-purchasable color but still opens confirmation popup.
 - Owned node shows purchased marker and remains browsable.
-2. In tap-to-buy mode (`skillsBuyOnTap = true`):
+2. Non-refundable visuals and labels:
+- Assign an intrinsic non-refundable skill (for example `banking`) and verify node uses non-refundable colors.
+- Verify unassigned non-refundable nodes use the darker/greyer red set and assigned non-refundable nodes use full red.
+- Verify an intrinsic non-refundable popup shows `Not Refundable (Including Required Skills)`.
+- Assign `shouldersOfGiants` and verify assigned prerequisites in its full required chain (for example
+  `scientificPlanets` and its requirements) switch to non-refundable colors.
+- Open one of those prerequisites and verify label `Not Refundable (Required by: Shoulders of Giants)`.
+- Assign a refundable skill and verify it uses the owned green color set without showing the purchased overlay.
+3. Reversion:
+- Unassign the top intrinsic non-refundable skill and verify prerequisite colors/labels revert.
+4. In tap-to-buy mode (`skillsBuyOnTap = true`):
 - Non-purchasable nodes are non-interactable.
 - Purchasable nodes are interactable and can be assigned directly.
-3. Confirm popup:
+5. Confirm popup:
 - `confirm` button disabled when requirements/cost/exclusive/refundability checks fail.

--- a/ProjectSettings/GvhProjectSettings.xml
+++ b/ProjectSettings/GvhProjectSettings.xml
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <projectSettings>
   <projectSetting name="Google.IOSResolver.VerboseLoggingEnabled" value="False" />
+  <projectSetting name="Google.PackageManagerResolver.VerboseLoggingEnabled" value="False" />
+  <projectSetting name="Google.VersionHandler.VerboseLoggingEnabled" value="False" />
 </projectSettings>

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -98,7 +98,7 @@ QualitySettings:
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 0.7
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -134,7 +134,7 @@ QualitySettings:
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 1
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -170,7 +170,7 @@ QualitySettings:
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 1.5
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -206,7 +206,7 @@ QualitySettings:
     softVegetation: 1
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
-    vSyncCount: 1
+    vSyncCount: 0
     lodBias: 2
     maximumLODLevel: 0
     streamingMipmapsActive: 0


### PR DESCRIPTION
## Summary
- add effective not-refundable reason resolution in skill tree nodes, including direct, dynamic-lock, and transitive prerequisite cases
- apply new owned/non-refundable button color states and line color handling so node + line visuals match refundability rules
- update confirmation popup to show precise not-refundable reason copy from SkillTreeManager
- extend UI theme/default theme assets for new skill-tree color sets and refresh skill-tree docs
- carry forward workspace runtime/settings updates (60 FPS fallback when frame cap unset, quality vSync disabled, resolver verbose flags)

## Testing
- Not run (Unity/manual)