### PR TITLE
fix(offline): refine desktop/mobile away time constraints and UI threshold

### DIFF
--- a/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflineLifecycleCoordinatorTests.cs
@@ -35,8 +35,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 phase => savePhases.Add(phase),
                 () => reloadCount++,
+                null,
                 reloadOnFocusGain: false,
-                saveOnFocusLoss: true);
+                saveOnFocusLoss: true,
+                saveOnPause: true);
 
             lifecycleEvents.RaiseFocusChanged(false);
             lifecycleEvents.RaisePauseChanged(true);
@@ -58,8 +60,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 phase => savePhases.Add(phase),
                 () => { },
+                null,
                 reloadOnFocusGain: false,
-                saveOnFocusLoss: false);
+                saveOnFocusLoss: false,
+                saveOnPause: true);
 
             lifecycleEvents.RaisePauseChanged(true);
             lifecycleEvents.RaisePauseChanged(false);
@@ -81,8 +85,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 phase => savePhases.Add(phase),
                 () => reloadCount++,
+                null,
                 reloadOnFocusGain: false,
-                saveOnFocusLoss: true);
+                saveOnFocusLoss: true,
+                saveOnPause: true);
 
             lifecycleEvents.RaiseFocusChanged(false);
             lifecycleEvents.RaiseFocusChanged(true);
@@ -106,8 +112,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 _ => saveCount++,
                 () => reloadCount++,
+                null,
                 reloadOnFocusGain: true,
-                saveOnFocusLoss: true);
+                saveOnFocusLoss: true,
+                saveOnPause: true);
 
             lifecycleEvents.RaiseFocusChanged(true);
             lifecycleEvents.RaiseFocusChanged(false);
@@ -128,8 +136,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 _ => saveCount++,
                 () => reloadCount++,
+                null,
                 reloadOnFocusGain: true,
-                saveOnFocusLoss: true);
+                saveOnFocusLoss: true,
+                saveOnPause: true);
 
             coordinator.Dispose();
 
@@ -152,8 +162,10 @@ namespace Tests.Systems
                 lifecycleEvents,
                 _ => saveCount++,
                 () => { },
+                null,
                 reloadOnFocusGain: false,
-                saveOnFocusLoss: false);
+                saveOnFocusLoss: false,
+                saveOnPause: true);
 
             lifecycleEvents.RaiseFocusChanged(false);
 

--- a/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs
+++ b/Assets/Editor/Tests/Systems/OfflinePersistenceRegressionTests.cs
@@ -77,7 +77,7 @@ namespace Tests.Systems
             {
                 current.dateQuitString = clock.UtcNow.ToString(CultureInfo.InvariantCulture);
                 Assert.IsTrue(saveStore.TrySave(current, out _, out string saveError), saveError);
-            }, () => { }, reloadOnFocusGain: false, saveOnFocusLoss: true);
+            }, () => { }, null, reloadOnFocusGain: false, saveOnFocusLoss: true, saveOnPause: true);
 
             lifecycleEvents.RaiseFocusChanged(false);
             clock.UtcNow = clock.UtcNow.AddSeconds(awaySeconds);

--- a/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs
+++ b/Assets/Scripts/Expansion/Oracle.RuntimeSeams.cs
@@ -26,6 +26,8 @@ namespace Expansion
      * Change notes:
      * - Lifecycle routing changes here affect save-on-background/quit behavior on all platforms.
      * - Focus-loss save policy is mobile-only; desktop focus changes must not stamp quit timestamps.
+     * - Cold-start replay gating for lifecycle save behavior is enforced in Oracle.Persistence (SaveForLifecycleTrigger);
+     *   this file should continue routing events only, without duplicating save policy state.
      * - If seam initialization order changes, ensure Oracle.Awake still initializes before any save/load callback.
      */
     public partial class Oracle
@@ -51,10 +53,12 @@ namespace Expansion
             {
                 _offlineLifecycleCoordinator = new OfflineLifecycleCoordinator(
                     _lifecycleEvents,
-                    OnLifecycleSaveRequested,
-                    OnLifecycleReloadRequested,
+                    OnLifecycleSaveRequested, // Save triggers
+                    OnLifecycleReloadRequested, // Optional reload on focus (mobile only, now disabled)
+                    OnLifecycleFocusGained, // Optional offline time on focus (mobile only)
                     ShouldReloadOnFocusGain(),
-                    ShouldSaveOnFocusLoss());
+                    ShouldSaveOnFocusLoss(),
+                    ShouldSaveOnPause());
             }
         }
 
@@ -65,11 +69,9 @@ namespace Expansion
 
         private static bool ShouldReloadOnFocusGain()
         {
-#if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
-            return true;
-#else
+            // By design, mobile now relies on OnLifecycleFocusGained to grant offline time 
+            // without fully reloading the game on focus/unfocus.
             return false;
-#endif
         }
 
         private static bool ShouldSaveOnFocusLoss()
@@ -77,6 +79,16 @@ namespace Expansion
 #if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
             return true;
 #else
+            return false;
+#endif
+        }
+
+        private static bool ShouldSaveOnPause()
+        {
+#if !UNITY_EDITOR && (UNITY_IOS || UNITY_ANDROID)
+            return true;
+#else
+            // Desktop pause (minimizing) should NOT stamp the quit timestamp to prevent gaining offline time while playing.
             return false;
 #endif
         }
@@ -94,6 +106,14 @@ namespace Expansion
         private void OnLifecycleReloadRequested()
         {
             Load();
+        }
+
+        private void OnLifecycleFocusGained()
+        {
+            Debug.LogWarning(
+                $"[OfflineTimeDiag] AppLifecycle | phase=OnApplicationFocusGained, platform={Application.platform}, " +
+                $"routing=AwayForSeconds");
+            AwayForSeconds();
         }
 
         internal void ConfigureRuntimeSeamsForTests(

--- a/Assets/Scripts/Systems/OfflineProgressSystem.cs
+++ b/Assets/Scripts/Systems/OfflineProgressSystem.cs
@@ -238,7 +238,7 @@ namespace Systems
             string colorS = "<color=#00E1FF>";
             ui?.AwayForHeader?.gameObject.SetActive(true);
             if (ui?.AwayForHeader != null) ui.AwayForHeader.text = "Welcome Back!";
-            ui?.ReturnScreen?.SetActive(awayTime >= 60 || awayTime < 0);
+            ui?.ReturnScreen?.SetActive(awayTime >= 120 || awayTime < 0);
             ui?.OfflineTimeInstructions?.SetActive(true);
             if (awayTime < 0)
             {

--- a/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs
+++ b/Assets/Scripts/Systems/Save/OfflineLifecycleCoordinator.cs
@@ -18,9 +18,9 @@ namespace Systems.Save
      * - Dispose() (unsubscribes)
      * Owns vs delegates:
      * - Owns the lifecycle policy matrix:
-     *   pause(true) => request save, focus(false) => optional save (platform policy), quit => request save,
-     *   focus(true) => optional reload.
-     * - Delegates actual save/load work to injected callbacks.
+     *   pause(saveOnPause) => request save, focus(false) => optional save (platform policy), quit => request save,
+     *   focus(true) => optional reload or optional offline time calculation.
+     * - Delegates actual save/load/time work to injected callbacks.
      *
      * Interacts with:
      * - Systems.Save.ILifecycleEvents
@@ -37,23 +37,29 @@ namespace Systems.Save
         private readonly ILifecycleEvents _events;
         private readonly Action<LifecycleSaveTrigger> _requestSaveForLifecycle;
         private readonly Action _requestReloadOnFocusGain;
+        private readonly Action _requestOfflineTimeOnFocusGain;
         private readonly bool _reloadOnFocusGain;
         private readonly bool _saveOnFocusLoss;
+        private readonly bool _saveOnPause;
         private bool _disposed;
 
         public OfflineLifecycleCoordinator(
             ILifecycleEvents lifecycleEvents,
             Action<LifecycleSaveTrigger> requestSaveForLifecycle,
             Action requestReloadOnFocusGain,
+            Action requestOfflineTimeOnFocusGain,
             bool reloadOnFocusGain,
-            bool saveOnFocusLoss)
+            bool saveOnFocusLoss,
+            bool saveOnPause)
         {
             _events = lifecycleEvents ?? throw new ArgumentNullException(nameof(lifecycleEvents));
             _requestSaveForLifecycle =
                 requestSaveForLifecycle ?? throw new ArgumentNullException(nameof(requestSaveForLifecycle));
-            _requestReloadOnFocusGain = requestReloadOnFocusGain ?? throw new ArgumentNullException(nameof(requestReloadOnFocusGain));
+            _requestReloadOnFocusGain = requestReloadOnFocusGain; // Can be null if unused
+            _requestOfflineTimeOnFocusGain = requestOfflineTimeOnFocusGain; // Can be null if unused
             _reloadOnFocusGain = reloadOnFocusGain;
             _saveOnFocusLoss = saveOnFocusLoss;
+            _saveOnPause = saveOnPause;
 
             _events.PauseChanged += HandlePauseChanged;
             _events.FocusChanged += HandleFocusChanged;
@@ -73,16 +79,23 @@ namespace Systems.Save
         private void HandlePauseChanged(bool paused)
         {
             if (!paused) return;
-            _requestSaveForLifecycle(LifecycleSaveTrigger.Pause);
+            if (_saveOnPause)
+            {
+                _requestSaveForLifecycle(LifecycleSaveTrigger.Pause);
+            }
         }
 
         private void HandleFocusChanged(bool focused)
         {
             if (focused)
             {
-                if (_reloadOnFocusGain)
+                if (_reloadOnFocusGain && _requestReloadOnFocusGain != null)
                 {
                     _requestReloadOnFocusGain();
+                }
+                else if (_requestOfflineTimeOnFocusGain != null)
+                {
+                    _requestOfflineTimeOnFocusGain();
                 }
 
                 return;


### PR DESCRIPTION
Desktop pause no longer generates a quit timestamp to prevent double dipping offline time on minimization. Mobile focus grain routing now updates away time dynamically via AwayForSeconds without triggering a full game reload. The UI notification for offline time now strictly appears only if more than 120 seconds have transpired.